### PR TITLE
Fix shell injection in release-note generation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -219,12 +219,13 @@ jobs:
         id: release_notes
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           if [ -z "$OPENAI_API_KEY" ]; then
             echo "OPENAI_API_KEY not set, using default release notes"
             echo "use_default=true" >> $GITHUB_OUTPUT
           else
-            bun run scripts/generate-release-notes.ts ${{ github.ref_name }} > release-notes.md
+            bun run scripts/generate-release-notes.ts "$RELEASE_TAG" > release-notes.md
             echo "use_default=false" >> $GITHUB_OUTPUT
           fi
 

--- a/scripts/generate-release-notes.test.ts
+++ b/scripts/generate-release-notes.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { spawnSync } from "child_process";
@@ -7,19 +7,25 @@ import { spawnSync } from "child_process";
 const scriptPath = join(import.meta.dir, "generate-release-notes.ts");
 const temporaryDirectories: string[] = [];
 
+function git(cwd: string, ...args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
+  expect(result.status).toBe(0);
+  return result.stdout.trim();
+}
+
 function createRepository(): string {
   const directory = mkdtempSync(join(tmpdir(), "release-notes-test-"));
   temporaryDirectories.push(directory);
 
   for (const args of [["init", "--quiet"], ["config", "user.email", "test@example.com"], ["config", "user.name", "Test User"]]) {
-    expect(spawnSync("git", args, { cwd: directory }).status).toBe(0);
+    git(directory, ...args);
   }
 
   return directory;
 }
 
-function runReleaseNotes(tag: string, cwd: string) {
-  return spawnSync("bun", [scriptPath, tag], {
+function runReleaseNotes(tag: string, cwd: string, preload?: string) {
+  return spawnSync("bun", [...(preload ? ["--preload", preload] : []), scriptPath, tag], {
     cwd,
     encoding: "utf-8",
     env: { ...process.env, OPENAI_API_KEY: "" },
@@ -44,15 +50,58 @@ test("treats a metacharacter-containing tag as a literal Git revision", () => {
 
 test("generates default notes for a normal tag with no commits", () => {
   const repository = createRepository();
-  const emptyTree = spawnSync("git", ["mktree"], {
-    cwd: repository,
-    input: "",
-    encoding: "utf-8",
-  }).stdout.trim();
-  expect(spawnSync("git", ["tag", "v1.2.3", emptyTree], { cwd: repository }).status).toBe(0);
+  git(repository, "commit", "--allow-empty", "-m", "Initial commit");
+  git(repository, "tag", "v1.2.2");
+  git(repository, "tag", "v1.2.3");
 
   const result = runReleaseNotes("v1.2.3", repository);
 
   expect(result.status).toBe(0);
   expect(result.stdout).toBe("# v1.2.3\n\nVersion bump release.\n");
+}, 15_000);
+
+test("generates notes from only the commits and source changes between two tags", () => {
+  const repository = createRepository();
+  const sourceFile = "packages/core/src/index.ts";
+  mkdirSync(join(repository, "packages/core/src"), { recursive: true });
+  writeFileSync(join(repository, sourceFile), "export const count = 1;\n");
+  git(repository, "add", ".");
+  git(repository, "commit", "-m", "Initial implementation before release");
+  git(repository, "tag", "v1.2.2");
+
+  writeFileSync(join(repository, sourceFile), "export const count = 2;\n");
+  writeFileSync(join(repository, "packages/core/src/index.test.ts"), "// Test-only change\n");
+  writeFileSync(join(repository, "README.md"), "Documentation-only change\n");
+  git(repository, "add", ".");
+  git(repository, "commit", "-m", "feat: update count | preserve delimiter");
+  const releaseCommit = git(repository, "rev-parse", "HEAD");
+  git(repository, "tag", "-a", "v1.2.3", "-m", "Release 1.2.3");
+
+  writeFileSync(join(repository, sourceFile), "export const count = 3;\n");
+  git(repository, "add", ".");
+  git(repository, "commit", "-m", "Later change after release");
+
+  // Keep real Git and CLI execution; replace only the external text generator.
+  const preload = join(repository, "mock-ai.ts");
+  writeFileSync(preload, `
+    import { mock } from "bun:test";
+    mock.module(${JSON.stringify(import.meta.resolve("ai"))}, () => ({
+      generateText: async ({ prompt }) => ({ text: prompt }),
+    }));
+  `);
+
+  const result = runReleaseNotes("v1.2.3", repository, preload);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("Generate release notes for version v1.2.3");
+  expect(result.stdout).toContain(`- feat: update count | preserve delimiter (${releaseCommit.substring(0, 7)})`);
+  expect(result.stdout).not.toContain("Initial implementation before release");
+  expect(result.stdout).not.toContain("Later change after release");
+  expect(result.stdout).toContain("Packages with actual code changes in this release: @data-slot/core");
+  expect(result.stdout).toContain(`### ${sourceFile}`);
+  expect(result.stdout).toContain("-export const count = 1;");
+  expect(result.stdout).toContain("+export const count = 2;");
+  expect(result.stdout).not.toContain("export const count = 3;");
+  expect(result.stdout).not.toContain("index.test.ts");
+  expect(result.stdout).not.toContain("README.md");
 }, 15_000);

--- a/scripts/generate-release-notes.test.ts
+++ b/scripts/generate-release-notes.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+
+const scriptPath = join(import.meta.dir, "generate-release-notes.ts");
+const temporaryDirectories: string[] = [];
+
+function createRepository(): string {
+  const directory = mkdtempSync(join(tmpdir(), "release-notes-test-"));
+  temporaryDirectories.push(directory);
+
+  for (const args of [["init", "--quiet"], ["config", "user.email", "test@example.com"], ["config", "user.name", "Test User"]]) {
+    expect(spawnSync("git", args, { cwd: directory }).status).toBe(0);
+  }
+
+  return directory;
+}
+
+function runReleaseNotes(tag: string, cwd: string) {
+  return spawnSync("bun", [scriptPath, tag], {
+    cwd,
+    encoding: "utf-8",
+    env: { ...process.env, OPENAI_API_KEY: "" },
+  });
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("treats a metacharacter-containing tag as a literal Git revision", () => {
+  const repository = createRepository();
+  const marker = join(repository, "shell-command-ran");
+  const result = runReleaseNotes(`missing-tag; touch ${marker}; #`, repository);
+
+  expect(existsSync(marker)).toBe(false);
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("Version bump release.");
+}, 15_000);
+
+test("generates default notes for a normal tag with no commits", () => {
+  const repository = createRepository();
+  const emptyTree = spawnSync("git", ["mktree"], {
+    cwd: repository,
+    input: "",
+    encoding: "utf-8",
+  }).stdout.trim();
+  expect(spawnSync("git", ["tag", "v1.2.3", emptyTree], { cwd: repository }).status).toBe(0);
+
+  const result = runReleaseNotes("v1.2.3", repository);
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toBe("# v1.2.3\n\nVersion bump release.\n");
+}, 15_000);

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -14,6 +14,12 @@ import { execFileSync } from "child_process";
 import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";
 
+type TagRange = {
+  currentRevision: string;
+  previousRevision: string | null;
+  range: string;
+};
+
 function getPreviousTag(currentTag: string): string | null {
   try {
     const tags = execFileSync("git", ["tag", "--sort=-version:refname"], {
@@ -60,21 +66,29 @@ function resolveRevision(revision: string): string | null {
   }
 }
 
+function resolveTagRange(tag: string): TagRange | null {
+  const previousTag = getPreviousTag(tag);
+  const currentRevision = resolveRevision(tag);
+  if (!currentRevision) return null;
+
+  const previousRevision = previousTag ? resolveRevision(previousTag) : null;
+  const range = previousRevision
+    ? `${previousRevision}..${currentRevision}`
+    : currentRevision;
+
+  return { currentRevision, previousRevision, range };
+}
+
 function getCommitsSinceTag(
   tag: string
 ): Array<{ hash: string; message: string; author: string }> {
   try {
-    const previousTag = getPreviousTag(tag);
-    const currentRevision = resolveRevision(tag);
-    if (!currentRevision) return [];
-    const previousRevision = previousTag ? resolveRevision(previousTag) : null;
-    const range = previousRevision
-      ? `${previousRevision}..${currentRevision}`
-      : currentRevision;
+    const tagRange = resolveTagRange(tag);
+    if (!tagRange) return [];
 
     const log = execFileSync(
       "git",
-      ["log", range, "--pretty=format:%H|%s|%an", "--no-merges"],
+      ["log", tagRange.range, "--pretty=format:%H|%s|%an", "--no-merges"],
       { encoding: "utf-8" }
     ).trim();
 
@@ -95,19 +109,16 @@ function getChangedFiles(
   tag: string
 ): Array<{ file: string; changes: string; packageName: string }> {
   try {
-    const previousTag = getPreviousTag(tag);
-    const currentRevision = resolveRevision(tag);
-    if (!currentRevision) return [];
-    const previousRevision = previousTag ? resolveRevision(previousTag) : null;
-    const range = previousRevision
-      ? `${previousRevision}..${currentRevision}`
-      : currentRevision;
+    const tagRange = resolveTagRange(tag);
+    if (!tagRange) return [];
 
-    console.error(`Comparing: ${range}`);
+    console.error(`Comparing: ${tagRange.range}`);
 
-    const files = execFileSync("git", ["diff", "--name-only", range], {
-      encoding: "utf-8",
-    })
+    const files = execFileSync(
+      "git",
+      ["diff", "--name-only", tagRange.range],
+      { encoding: "utf-8" }
+    )
       .trim()
       .split("\n")
       .filter(Boolean);
@@ -135,10 +146,10 @@ function getChangedFiles(
       if (!isSourceFile) continue;
 
       try {
-        const diffBase = previousRevision || "HEAD~1";
+        const diffBase = tagRange.previousRevision || "HEAD~1";
         const diff = execFileSync(
           "git",
-          ["diff", `${diffBase}..${currentRevision}`, "--", file],
+          ["diff", `${diffBase}..${tagRange.currentRevision}`, "--", file],
           {
             encoding: "utf-8",
             maxBuffer: 1024 * 1024,

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -10,13 +10,13 @@
  *   - Git repository with tags
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";
 
 function getPreviousTag(currentTag: string): string | null {
   try {
-    const tags = execSync("git tag --sort=-version:refname", {
+    const tags = execFileSync("git", ["tag", "--sort=-version:refname"], {
       encoding: "utf-8",
     })
       .trim()
@@ -47,18 +47,35 @@ function getPreviousTag(currentTag: string): string | null {
   }
 }
 
+function resolveRevision(revision: string): string | null {
+  try {
+    return execFileSync(
+      "git",
+      ["rev-parse", "--verify", "--end-of-options", `${revision}^{commit}`],
+      { encoding: "utf-8" }
+    ).trim();
+  } catch {
+    console.error(`Revision ${revision} could not be resolved to a commit`);
+    return null;
+  }
+}
+
 function getCommitsSinceTag(
   tag: string
 ): Array<{ hash: string; message: string; author: string }> {
   try {
     const previousTag = getPreviousTag(tag);
-    const range = previousTag ? `${previousTag}..${tag}` : tag;
+    const currentRevision = resolveRevision(tag);
+    if (!currentRevision) return [];
+    const previousRevision = previousTag ? resolveRevision(previousTag) : null;
+    const range = previousRevision
+      ? `${previousRevision}..${currentRevision}`
+      : currentRevision;
 
-    const log = execSync(
-      `git log ${range} --pretty=format:"%H|%s|%an" --no-merges`,
-      {
-        encoding: "utf-8",
-      }
+    const log = execFileSync(
+      "git",
+      ["log", range, "--pretty=format:%H|%s|%an", "--no-merges"],
+      { encoding: "utf-8" }
     ).trim();
 
     if (!log) return [];
@@ -79,11 +96,16 @@ function getChangedFiles(
 ): Array<{ file: string; changes: string; packageName: string }> {
   try {
     const previousTag = getPreviousTag(tag);
-    const range = previousTag ? `${previousTag}..${tag}` : tag;
+    const currentRevision = resolveRevision(tag);
+    if (!currentRevision) return [];
+    const previousRevision = previousTag ? resolveRevision(previousTag) : null;
+    const range = previousRevision
+      ? `${previousRevision}..${currentRevision}`
+      : currentRevision;
 
     console.error(`Comparing: ${range}`);
 
-    const files = execSync(`git diff --name-only ${range}`, {
+    const files = execFileSync("git", ["diff", "--name-only", range], {
       encoding: "utf-8",
     })
       .trim()
@@ -113,8 +135,10 @@ function getChangedFiles(
       if (!isSourceFile) continue;
 
       try {
-        const diff = execSync(
-          `git diff ${previousTag || "HEAD~1"}..${tag} -- "${file}"`,
+        const diffBase = previousRevision || "HEAD~1";
+        const diff = execFileSync(
+          "git",
+          ["diff", `${diffBase}..${currentRevision}`, "--", file],
           {
             encoding: "utf-8",
             maxBuffer: 1024 * 1024,


### PR DESCRIPTION
Release tags and changed filenames were interpolated into shell commands during release-note generation, allowing shell metacharacters to be executed. Pass the workflow tag through a quoted environment variable and invoke Git with argument arrays instead. Resolve tag references to commit IDs with `--end-of-options` before building comparison ranges, sharing that resolution between commit and file collection.

Regression tests cover an injection attempt, an empty release between valid commit tags, and a successful comparison from a lightweight tag to an annotated tag. The comparison test checks commit boundaries, source diffs, and exclusion of test and documentation changes while mocking only AI generation.

Validation: `bun test scripts/generate-release-notes.test.ts` (3 passed), `git diff --check`, and a clean merge check against current `origin/main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/data-slot/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791540791&installation_model_id=433409&pr_number=11&repository=bejamas%2Fdata-slot&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fdata-slot%2Fpull%2F11&signature=6df2c5f390b204ba45aa3d8d7bf114ede7161e96029bfeb5e86afae90dabf559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->