### PR TITLE
refactor: separate component collections and select positioning

### DIFF
--- a/packages/combobox/src/combobox-collection.ts
+++ b/packages/combobox/src/combobox-collection.ts
@@ -1,0 +1,168 @@
+import { ensureId, ensureItemVisibleInContainer, getPart, getParts, setAria } from "@data-slot/core";
+import type { ComboboxItemToStringValue } from "./types";
+
+type ComboboxFilter = (inputValue: string, itemValue: string, itemLabel: string) => boolean;
+
+interface ComboboxCollectionOptions {
+  root: Element;
+  container: HTMLElement;
+  input: HTMLInputElement;
+  emptySlot: HTMLElement | null;
+  filter: ComboboxFilter;
+  itemToStringValue: ComboboxItemToStringValue | null;
+}
+
+export interface ComboboxCollection {
+  cache(selectedValue: string | null): void;
+  filter(query: string): void;
+  select(value: string | null): void;
+  highlight(index: number): void;
+  clearHighlight(): void;
+  setItemToStringValue(itemToStringValue: ComboboxItemToStringValue | null): void;
+  readonly items: readonly HTMLElement[];
+  readonly enabled: readonly HTMLElement[];
+  readonly highlightedIndex: number;
+  indexOf(item: HTMLElement): number | undefined;
+  valueOf(item: HTMLElement): string | undefined;
+  labelFor(value: string | null): string;
+}
+
+export function createComboboxCollection({
+  root,
+  container,
+  input,
+  emptySlot,
+  filter,
+  itemToStringValue: initialItemToStringValue,
+}: ComboboxCollectionOptions): ComboboxCollection {
+  const content = getPart<HTMLElement>(root, "combobox-content") ?? container;
+  let allItems: HTMLElement[] = [];
+  let enabledVisibleItems: HTMLElement[] = [];
+  let itemToEnabledIndex = new Map<HTMLElement, number>();
+  let highlightedIndex = -1;
+  let itemToStringValue = initialItemToStringValue;
+
+  const isItemDisabled = (item: HTMLElement) =>
+    item.hasAttribute("disabled") || item.hasAttribute("data-disabled") || item.getAttribute("aria-disabled") === "true";
+
+  const getItemLabel = (item: HTMLElement) => {
+    if (item.dataset["label"]) return item.dataset["label"];
+    let directText = "";
+    for (const node of item.childNodes) {
+      if (node.nodeType === Node.TEXT_NODE) directText += node.textContent;
+    }
+    return directText.trim() || item.textContent?.trim() || "";
+  };
+
+  const valueOf = (item: HTMLElement): string | undefined =>
+    item.hasAttribute("data-value") ? item.getAttribute("data-value")! : undefined;
+
+  const itemByValue = (value: string | null): HTMLElement | null => {
+    if (value === null) return null;
+    return getParts<HTMLElement>(container, "combobox-item").find((item) => valueOf(item) === value) ?? null;
+  };
+
+  const labelFor = (value: string | null) => {
+    const item = itemByValue(value);
+    return itemToStringValue ? itemToStringValue(item, value) : item ? getItemLabel(item) : "";
+  };
+
+  const syncItemSelectedState = (item: HTMLElement, selected: boolean) => {
+    setAria(item, "selected", selected);
+    item.toggleAttribute("data-selected", selected);
+    for (const indicator of getParts<HTMLElement>(item, "combobox-item-indicator")) {
+      indicator.hidden = !selected;
+    }
+  };
+
+  const rebuildVisibleItems = () => {
+    enabledVisibleItems = allItems.filter((item) => !item.hidden && !isItemDisabled(item));
+    itemToEnabledIndex = new Map(enabledVisibleItems.map((item, index) => [item, index]));
+  };
+
+  const normalizeVisibleSeparators = () => {
+    for (const separator of getParts<HTMLElement>(container, "combobox-separator")) separator.hidden = true;
+    const children = Array.from(container.children).filter((child): child is HTMLElement => child instanceof HTMLElement);
+    for (let index = 0; index < children.length; index++) {
+      const current = children[index]!;
+      if (current.dataset["slot"] === "combobox-separator" || current.hidden) continue;
+      let firstVisibleSeparator: HTMLElement | null = null;
+      for (let nextIndex = index + 1; nextIndex < children.length; nextIndex++) {
+        const next = children[nextIndex]!;
+        if (next.dataset["slot"] === "combobox-separator") {
+          firstVisibleSeparator ??= next;
+        } else if (!next.hidden) {
+          if (firstVisibleSeparator) firstVisibleSeparator.hidden = false;
+          break;
+        }
+      }
+    }
+  };
+
+  const clearHighlight = () => {
+    for (const item of allItems) item.removeAttribute("data-highlighted");
+    highlightedIndex = -1;
+    input.removeAttribute("aria-activedescendant");
+  };
+
+  return {
+    cache(selectedValue) {
+      allItems = getParts<HTMLElement>(container, "combobox-item");
+      for (const item of allItems) {
+        item.setAttribute("role", "option");
+        ensureId(item, "combobox-item");
+        item.toggleAttribute("aria-disabled", isItemDisabled(item));
+        if (isItemDisabled(item)) item.setAttribute("aria-disabled", "true");
+        syncItemSelectedState(item, valueOf(item) === selectedValue);
+      }
+      for (const group of getParts<HTMLElement>(container, "combobox-group")) {
+        group.setAttribute("role", "group");
+        const label = getPart<HTMLElement>(group, "combobox-label");
+        if (label) group.setAttribute("aria-labelledby", ensureId(label, "combobox-label"));
+      }
+      rebuildVisibleItems();
+    },
+    filter(query) {
+      const trimmed = query.trim();
+      let visibleCount = 0;
+      for (const item of allItems) {
+        const matches = trimmed === "" || filter(trimmed, valueOf(item) ?? "", getItemLabel(item));
+        item.hidden = !matches;
+        if (matches) visibleCount++;
+      }
+      for (const group of getParts<HTMLElement>(container, "combobox-group")) {
+        group.hidden = getParts<HTMLElement>(group, "combobox-item").every((item) => item.hidden);
+      }
+      normalizeVisibleSeparators();
+      if (emptySlot) emptySlot.hidden = visibleCount > 0;
+      content.toggleAttribute("data-empty", visibleCount === 0);
+      rebuildVisibleItems();
+    },
+    select(value) {
+      const items = allItems.length > 0 ? allItems : getParts<HTMLElement>(container, "combobox-item");
+      for (const item of items) syncItemSelectedState(item, valueOf(item) === value);
+    },
+    highlight(index) {
+      for (const item of allItems) item.removeAttribute("data-highlighted");
+      const item = enabledVisibleItems[index];
+      if (!item) return clearHighlight();
+      item.setAttribute("data-highlighted", "");
+      input.setAttribute("aria-activedescendant", item.id);
+      const scrollContainer = container.contains(item) && container.scrollHeight > container.clientHeight
+        ? container
+        : content;
+      ensureItemVisibleInContainer(item, scrollContainer);
+      highlightedIndex = index;
+    },
+    clearHighlight,
+    setItemToStringValue(nextItemToStringValue) {
+      itemToStringValue = nextItemToStringValue;
+    },
+    get items() { return allItems; },
+    get enabled() { return enabledVisibleItems; },
+    get highlightedIndex() { return highlightedIndex; },
+    indexOf(item) { return itemToEnabledIndex.get(item); },
+    valueOf,
+    labelFor,
+  };
+}

--- a/packages/combobox/src/combobox-collection.ts
+++ b/packages/combobox/src/combobox-collection.ts
@@ -23,6 +23,7 @@ export interface ComboboxCollection {
   readonly enabled: readonly HTMLElement[];
   readonly highlightedIndex: number;
   indexOf(item: HTMLElement): number | undefined;
+  isDisabled(item: HTMLElement): boolean;
   valueOf(item: HTMLElement): string | undefined;
   labelFor(value: string | null): string;
 }
@@ -162,6 +163,7 @@ export function createComboboxCollection({
     get enabled() { return enabledVisibleItems; },
     get highlightedIndex() { return highlightedIndex; },
     indexOf(item) { return itemToEnabledIndex.get(item); },
+    isDisabled: isItemDisabled,
     valueOf,
     labelFor,
   };

--- a/packages/combobox/src/configuration.ts
+++ b/packages/combobox/src/configuration.ts
@@ -1,0 +1,35 @@
+import { getDataBool, getDataEnum, getDataNumber, getDataString } from "@data-slot/core";
+import type { Align, ComboboxOptions, Side } from "./types";
+
+const SIDES = ["top", "bottom"] as const;
+const ALIGNS = ["start", "center", "end"] as const;
+
+/** Resolves authored configuration once, preserving the documented precedence rules. */
+export function resolveComboboxConfiguration(
+  root: Element, content: HTMLElement, authoredPositioner: HTMLElement | null, options: ComboboxOptions,
+) {
+  const enumValue = <T extends string>(key: string, allowed: readonly T[]) =>
+    getDataEnum(content, key, allowed) ?? (authoredPositioner ? getDataEnum(authoredPositioner, key, allowed) : undefined) ?? getDataEnum(root, key, allowed);
+  const numberValue = (key: string) => getDataNumber(content, key) ?? (authoredPositioner ? getDataNumber(authoredPositioner, key) : undefined) ?? getDataNumber(root, key);
+  const boolValue = (key: string) => getDataBool(content, key) ?? (authoredPositioner ? getDataBool(authoredPositioner, key) : undefined) ?? getDataBool(root, key);
+  return {
+    defaultValue: options.defaultValue ?? getDataString(root, "defaultValue") ?? null,
+    defaultOpen: options.defaultOpen ?? getDataBool(root, "defaultOpen") ?? false,
+    placeholder: options.placeholder ?? getDataString(root, "placeholder") ?? "",
+    disabled: options.disabled ?? getDataBool(root, "disabled") ?? false,
+    required: options.required ?? getDataBool(root, "required") ?? false,
+    name: options.name ?? getDataString(root, "name") ?? null,
+    openOnFocus: options.openOnFocus ?? getDataBool(root, "openOnFocus") ?? true,
+    autoHighlight: options.autoHighlight ?? getDataBool(root, "autoHighlight") ?? false,
+    customFilter: options.filter ?? null,
+    onValueChange: options.onValueChange,
+    onOpenChange: options.onOpenChange,
+    onInputValueChange: options.onInputValueChange,
+    preferredSide: options.side ?? enumValue("side", SIDES) ?? "bottom" as Side,
+    preferredAlign: options.align ?? enumValue("align", ALIGNS) ?? "start" as Align,
+    sideOffset: options.sideOffset ?? numberValue("sideOffset") ?? 4,
+    alignOffset: options.alignOffset ?? numberValue("alignOffset") ?? 0,
+    avoidCollisions: options.avoidCollisions ?? boolValue("avoidCollisions") ?? true,
+    collisionPadding: options.collisionPadding ?? numberValue("collisionPadding") ?? 8,
+  };
+}

--- a/packages/combobox/src/discovery.ts
+++ b/packages/combobox/src/discovery.ts
@@ -1,0 +1,10 @@
+import { getRoots, hasRootBinding } from "@data-slot/core";
+import type { ComboboxController } from "./types";
+
+const ROOT_BINDING_KEY = "@data-slot/combobox";
+
+export function discoverComboboxes(scope: ParentNode, createCombobox: (root: Element) => ComboboxController) {
+  return Array.from(getRoots(scope, "combobox"))
+    .filter((root) => !hasRootBinding(root, ROOT_BINDING_KEY))
+    .map(createCombobox);
+}

--- a/packages/combobox/src/index.test.ts
+++ b/packages/combobox/src/index.test.ts
@@ -974,6 +974,49 @@ describe("Combobox", () => {
       controller.destroy();
     });
 
+    for (const attribute of ["disabled", "data-disabled", "aria-disabled"]) {
+      for (const activation of ["pointer", "keyboard"]) {
+        it(`rejects ${activation} selection after ${attribute} is added while open`, () => {
+          let changes = 0;
+          const { input, items, controller } = setup({
+            onValueChange: () => { changes++; },
+          });
+          try {
+            controller.open();
+            input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+            items[0]!.setAttribute(attribute, attribute === "aria-disabled" ? "true" : "");
+
+            if (activation === "pointer") {
+              items[0]!.click();
+            } else {
+              input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            }
+
+            expect(controller.value).toBeNull();
+            expect(controller.isOpen).toBe(true);
+            expect(changes).toBe(0);
+          } finally {
+            controller.destroy();
+          }
+        });
+      }
+    }
+
+    it("allows clicking an item enabled while the popup is open", () => {
+      const { items, controller } = setup();
+      try {
+        controller.open();
+        items[3]!.removeAttribute("data-disabled");
+        items[3]!.removeAttribute("aria-disabled");
+        items[3]!.click();
+
+        expect(controller.value).toBe("disabled");
+        expect(controller.isOpen).toBe(false);
+      } finally {
+        controller.destroy();
+      }
+    });
+
     it("emits combobox:change on selection", () => {
       const { root, items, controller } = setup();
       let selectedValue: string | null | undefined;

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -1,6 +1,5 @@
 import {
   getPart,
-  getParts,
   containsWithPortals,
   reuseRootBinding,
   setRootBinding,
@@ -12,7 +11,6 @@ import {
   computeFloatingPosition,
   computeFloatingTransformOrigin,
   measurePopupContentRect,
-  ensureItemVisibleInContainer,
   createPositionSync,
   createPortalLifecycle,
   createPresenceLifecycle,
@@ -25,6 +23,7 @@ import type {
   Side,
 } from "./types";
 import { resolveComboboxConfiguration } from "./configuration";
+import { createComboboxCollection } from "./combobox-collection";
 import { discoverComboboxes } from "./discovery";
 
 export type {
@@ -100,7 +99,6 @@ export function createCombobox(
   // State
   let isOpen = false;
   let currentValue: string | null = defaultValue;
-  let highlightedIndex = -1;
   let keyboardMode = false;
   let openRenderedSide: Side | null = null;
   const cleanups: Array<() => void> = [];
@@ -111,12 +109,6 @@ export function createCombobox(
   let lastTabKeydownAt = -Infinity;
   let openOnNextFocusFromPointer = false;
   let suppressOpenOnNextFocus = false;
-
-  // Cached on open
-  let allItems: HTMLElement[] = [];
-  let visibleItems: HTMLElement[] = [];
-  let enabledVisibleItems: HTMLElement[] = [];
-  let itemToEnabledIndex = new Map<HTMLElement, number>();
 
   // Hidden input for form integration
   let hiddenInput: HTMLInputElement | null = null;
@@ -144,43 +136,6 @@ export function createCombobox(
   };
 
   const isMobileTouchEnvironment = isLikelyMobileTouchEnvironment();
-
-  const isItemDisabled = (el: HTMLElement) =>
-    el.hasAttribute("disabled") || el.hasAttribute("data-disabled") || el.getAttribute("aria-disabled") === "true";
-
-  const getItemLabel = (el: HTMLElement) => {
-    if (el.dataset["label"]) return el.dataset["label"];
-    // Try direct text nodes first (excludes child element text like check marks)
-    let directText = "";
-    for (const node of el.childNodes) {
-      if (node.nodeType === Node.TEXT_NODE) {
-        directText += node.textContent;
-      }
-    }
-    const trimmed = directText.trim();
-    if (trimmed) return trimmed;
-    // Fall back to full textContent for wrapped labels like <span>Apple</span>
-    return el.textContent?.trim() ?? "";
-  };
-
-  const getItemValue = (el: HTMLElement): string | undefined =>
-    el.hasAttribute("data-value") ? el.getAttribute("data-value")! : undefined;
-
-  const getItemByValue = (value: string | null): HTMLElement | null => {
-    if (value === null) return null;
-    const container = list ?? content;
-    const items = getParts<HTMLElement>(container, "combobox-item");
-    return items.find((el) => getItemValue(el) === value) ?? null;
-  };
-
-  // Get the display text for a given value
-  const getLabelForValue = (value: string | null): string => {
-    const item = getItemByValue(value);
-    if (itemToStringValue) {
-      return itemToStringValue(item, value);
-    }
-    return item ? getItemLabel(item) : "";
-  };
 
   // ARIA setup
   const inputId = ensureId(input, "combobox-input");
@@ -265,146 +220,15 @@ export function createCombobox(
     root.appendChild(hiddenInput);
   }
 
-  // Default filter: case-insensitive substring
-  const defaultFilter = (inputVal: string, _itemValue: string, itemLabel: string) =>
-    itemLabel.toLowerCase().includes(inputVal.toLowerCase());
-
-  const filterFn = customFilter ?? defaultFilter;
-
-  const syncItemSelectedState = (item: HTMLElement, selected: boolean) => {
-    setAria(item, "selected", selected);
-    if (selected) {
-      item.setAttribute("data-selected", "");
-    } else {
-      item.removeAttribute("data-selected");
-    }
-
-    const indicators = getParts<HTMLElement>(item, "combobox-item-indicator");
-    for (const indicator of indicators) {
-      indicator.hidden = !selected;
-    }
-  };
-
-  // Cache items from content
-  const cacheItems = () => {
-    const container = list ?? content;
-    allItems = getParts<HTMLElement>(container, "combobox-item");
-
-    for (const item of allItems) {
-      item.setAttribute("role", "option");
-      ensureId(item, "combobox-item");
-      if (isItemDisabled(item)) {
-        item.setAttribute("aria-disabled", "true");
-      } else {
-        item.removeAttribute("aria-disabled");
-      }
-
-      // Mark selected
-      const itemValue = getItemValue(item);
-      syncItemSelectedState(item, itemValue === currentValue);
-    }
-
-    // Set groups' ARIA
-    const groups = getParts<HTMLElement>(container, "combobox-group");
-    for (const group of groups) {
-      group.setAttribute("role", "group");
-      const label = getPart<HTMLElement>(group, "combobox-label");
-      if (label) {
-        const labelId = ensureId(label, "combobox-label");
-        group.setAttribute("aria-labelledby", labelId);
-      }
-    }
-
-    rebuildVisibleItems();
-  };
-
-  // Rebuild visible/enabled item caches after filtering
-  const rebuildVisibleItems = () => {
-    visibleItems = allItems.filter((el) => !el.hidden);
-    enabledVisibleItems = visibleItems.filter((el) => !isItemDisabled(el));
-    itemToEnabledIndex = new Map(enabledVisibleItems.map((el, i) => [el, i]));
-  };
-
-  // Normalize separators after filtering:
-  // - no leading/trailing visible separator
-  // - no adjacent visible separators
-  // - at most one visible separator between adjacent visible non-separator blocks
-  const normalizeVisibleSeparators = (container: HTMLElement) => {
-    const separators = getParts<HTMLElement>(container, "combobox-separator");
-    for (const sep of separators) {
-      sep.hidden = true;
-    }
-
-    const children = Array.from(container.children).filter(
-      (child): child is HTMLElement => child instanceof HTMLElement
-    );
-
-    for (let i = 0; i < children.length; i++) {
-      const current = children[i]!;
-      const currentIsSeparator = current.dataset["slot"] === "combobox-separator";
-      if (currentIsSeparator || current.hidden) continue;
-
-      let j = i + 1;
-      let firstVisibleSeparator: HTMLElement | null = null;
-      while (j < children.length) {
-        const next = children[j]!;
-        if (next.dataset["slot"] === "combobox-separator") {
-          firstVisibleSeparator ??= next;
-          j += 1;
-          continue;
-        }
-
-        if (next.hidden) {
-          j += 1;
-          continue;
-        }
-
-        if (firstVisibleSeparator) {
-          firstVisibleSeparator.hidden = false;
-        }
-        break;
-      }
-    }
-  };
-
-  // Filtering
-  const applyFilter = (inputVal: string) => {
-    const container = list ?? content;
-    const trimmed = inputVal.trim();
-    let visibleCount = 0;
-
-    for (const item of allItems) {
-      const itemValue = getItemValue(item) ?? "";
-      const itemLabel = getItemLabel(item);
-      const matches = trimmed === "" || filterFn(trimmed, itemValue, itemLabel);
-      item.hidden = !matches;
-      if (matches) visibleCount++;
-    }
-
-    // Hide groups where all items are hidden
-    const groups = getParts<HTMLElement>(container, "combobox-group");
-    for (const group of groups) {
-      const groupItems = getParts<HTMLElement>(group, "combobox-item");
-      const hasVisible = groupItems.some((el) => !el.hidden);
-      group.hidden = !hasVisible;
-    }
-
-    normalizeVisibleSeparators(container);
-
-    // Show/hide empty message
-    if (emptySlot) {
-      emptySlot.hidden = visibleCount > 0;
-    }
-
-    // Set data-empty on content
-    if (visibleCount === 0) {
-      content.setAttribute("data-empty", "");
-    } else {
-      content.removeAttribute("data-empty");
-    }
-
-    rebuildVisibleItems();
-  };
+  const collection = createComboboxCollection({
+    root,
+    container: list ?? content,
+    input,
+    emptySlot,
+    filter: customFilter ?? ((inputValue, _itemValue, itemLabel) =>
+      itemLabel.toLowerCase().includes(inputValue.toLowerCase())),
+    itemToStringValue,
+  });
 
   // Positioning
   const syncPositionCssVars = (positioner: HTMLElement, anchorRect: DOMRectReadOnly, side: Side) => {
@@ -490,36 +314,6 @@ export function createCombobox(
     ignoreScrollTarget: (target) => target instanceof Node && content.contains(target),
   });
 
-  const getHighlightScrollContainer = (item: HTMLElement): HTMLElement => {
-    if (list && list.contains(item) && list.scrollHeight > list.clientHeight) {
-      return list;
-    }
-    return content;
-  };
-
-  // Highlighting
-  const updateHighlight = (index: number) => {
-    for (const el of allItems) el.removeAttribute("data-highlighted");
-
-    const highlightedItem = enabledVisibleItems[index];
-    if (!highlightedItem) {
-      highlightedIndex = -1;
-      input.removeAttribute("aria-activedescendant");
-      return;
-    }
-
-    highlightedItem.setAttribute("data-highlighted", "");
-    input.setAttribute("aria-activedescendant", highlightedItem.id);
-    ensureItemVisibleInContainer(highlightedItem, getHighlightScrollContainer(highlightedItem));
-    highlightedIndex = index;
-  };
-
-  const clearHighlight = () => {
-    for (const el of allItems) el.removeAttribute("data-highlighted");
-    highlightedIndex = -1;
-    input.removeAttribute("aria-activedescendant");
-  };
-
   const setDataState = (state: "open" | "closed") => {
     root.setAttribute("data-state", state);
     content.setAttribute("data-state", state);
@@ -563,7 +357,7 @@ export function createCombobox(
       setDataState("open");
       presence.enter();
 
-      cacheItems();
+      collection.cache(currentValue);
       keyboardMode = false;
 
       // In popup-input mode, input text is transient search and should start empty on open.
@@ -572,14 +366,14 @@ export function createCombobox(
       }
 
       // Apply current filter
-      applyFilter(input.value);
+      collection.filter(input.value);
 
       // Highlight selected item if visible, else auto-highlight first
-      const selectedIndex = enabledVisibleItems.findIndex((el) => getItemValue(el) === currentValue);
+      const selectedIndex = collection.enabled.findIndex((item) => collection.valueOf(item) === currentValue);
       if (selectedIndex >= 0) {
-        updateHighlight(selectedIndex);
+        collection.highlight(selectedIndex);
       } else {
-        clearHighlight();
+        collection.clearHighlight();
       }
 
       positionSync.start();
@@ -595,7 +389,7 @@ export function createCombobox(
       openRenderedSide = null;
       setAria(input, "expanded", false);
       setDataState("closed");
-      clearHighlight();
+      collection.clearHighlight();
       keyboardMode = false;
 
       positionSync.stop();
@@ -605,7 +399,7 @@ export function createCombobox(
         input.value = "";
       } else {
         // Restore input text to committed value's label
-        const committedLabel = getLabelForValue(currentValue);
+        const committedLabel = collection.labelFor(currentValue);
         input.value = committedLabel;
       }
 
@@ -637,15 +431,9 @@ export function createCombobox(
       root.removeAttribute("data-value");
     }
 
-    // Update selected state on all items (may not be cached yet on init)
-    const container = list ?? content;
-    const items = allItems.length > 0 ? allItems : getParts<HTMLElement>(container, "combobox-item");
-    for (const item of items) {
-      const itemValue = getItemValue(item);
-      syncItemSelectedState(item, itemValue === value);
-    }
+    collection.select(value);
 
-    const resolvedLabel = getLabelForValue(value);
+    const resolvedLabel = collection.labelFor(value);
     if (!isPopupInputMode) {
       input.value = resolvedLabel;
     }
@@ -679,8 +467,8 @@ export function createCombobox(
   };
 
   const selectItem = (item: HTMLElement) => {
-    if (isItemDisabled(item)) return;
-    const value = getItemValue(item);
+    if (collection.indexOf(item) === undefined) return;
+    const value = collection.valueOf(item);
     if (value === undefined) return;
 
     updateValue(value);
@@ -695,10 +483,10 @@ export function createCombobox(
 
     updateValue(null);
     input.value = "";
-    clearHighlight();
+    collection.clearHighlight();
 
     if (isOpen) {
-      applyFilter(input.value);
+      collection.filter(input.value);
       positionSync.update();
     }
 
@@ -719,49 +507,49 @@ export function createCombobox(
         e.preventDefault();
         if (!isOpen) {
           updateOpenState(true);
-          if (autoHighlight && enabledVisibleItems.length > 0) {
-            updateHighlight(0);
+          if (autoHighlight && collection.enabled.length > 0) {
+            collection.highlight(0);
           }
           return;
         }
         keyboardMode = true;
-        const len = enabledVisibleItems.length;
+        const len = collection.enabled.length;
         if (len === 0) return;
-        updateHighlight(highlightedIndex === -1 ? 0 : (highlightedIndex + 1) % len);
+        collection.highlight(collection.highlightedIndex === -1 ? 0 : (collection.highlightedIndex + 1) % len);
         break;
       }
       case "ArrowUp": {
         e.preventDefault();
         if (!isOpen) {
           updateOpenState(true);
-          if (autoHighlight && enabledVisibleItems.length > 0) {
-            updateHighlight(enabledVisibleItems.length - 1);
+          if (autoHighlight && collection.enabled.length > 0) {
+            collection.highlight(collection.enabled.length - 1);
           }
           return;
         }
         keyboardMode = true;
-        const len = enabledVisibleItems.length;
+        const len = collection.enabled.length;
         if (len === 0) return;
-        updateHighlight(highlightedIndex === -1 ? len - 1 : (highlightedIndex - 1 + len) % len);
+        collection.highlight(collection.highlightedIndex === -1 ? len - 1 : (collection.highlightedIndex - 1 + len) % len);
         break;
       }
       case "Home":
         if (!isOpen) return;
         e.preventDefault();
         keyboardMode = true;
-        if (enabledVisibleItems.length > 0) updateHighlight(0);
+        if (collection.enabled.length > 0) collection.highlight(0);
         break;
       case "End":
         if (!isOpen) return;
         e.preventDefault();
         keyboardMode = true;
-        if (enabledVisibleItems.length > 0) updateHighlight(enabledVisibleItems.length - 1);
+        if (collection.enabled.length > 0) collection.highlight(collection.enabled.length - 1);
         break;
       case "Enter":
         if (!isOpen) return;
         e.preventDefault();
-        if (highlightedIndex >= 0 && highlightedIndex < enabledVisibleItems.length) {
-          selectItem(enabledVisibleItems[highlightedIndex]!);
+        if (collection.highlightedIndex >= 0 && collection.highlightedIndex < collection.enabled.length) {
+          selectItem(collection.enabled[collection.highlightedIndex]!);
         }
         break;
       case "Escape":
@@ -793,20 +581,20 @@ export function createCombobox(
     // Open if not already open
     if (!isOpen) {
       updateOpenState(true);
-      if (autoHighlight && hasTypedQuery && enabledVisibleItems.length > 0) {
-        updateHighlight(0);
-      } else if (highlightedIndex !== -1) {
-        clearHighlight();
+      if (autoHighlight && hasTypedQuery && collection.enabled.length > 0) {
+        collection.highlight(0);
+      } else if (collection.highlightedIndex !== -1) {
+        collection.clearHighlight();
       }
     } else {
       // Re-filter
-      applyFilter(val);
+      collection.filter(val);
 
       // Auto-highlight only after non-whitespace query input.
-      if (autoHighlight && hasTypedQuery && enabledVisibleItems.length > 0) {
-        updateHighlight(0);
+      if (autoHighlight && hasTypedQuery && collection.enabled.length > 0) {
+        collection.highlight(0);
       } else {
-        clearHighlight();
+        collection.clearHighlight();
       }
 
       // Update position after filter changes content size
@@ -896,20 +684,20 @@ export function createCombobox(
 
       if (keyboardMode) {
         keyboardMode = false;
-        if (item && itemToEnabledIndex.get(item) === highlightedIndex) return;
+        if (item && collection.indexOf(item) === collection.highlightedIndex) return;
       }
 
-      if (item && !isItemDisabled(item) && !item.hidden) {
-        const index = itemToEnabledIndex.get(item);
-        if (index !== undefined && index !== highlightedIndex) {
-          updateHighlight(index);
+      if (item && !item.hidden) {
+        const index = collection.indexOf(item);
+        if (index !== undefined && index !== collection.highlightedIndex) {
+          collection.highlight(index);
         }
       } else {
-        clearHighlight();
+        collection.clearHighlight();
       }
     }),
     on(content, "pointerleave", () => {
-      if (!keyboardMode) clearHighlight();
+      if (!keyboardMode) collection.clearHighlight();
     }),
     // Prevent mousedown on content from stealing focus from input
     on(content, "mousedown", (e) => {
@@ -954,6 +742,7 @@ export function createCombobox(
       }
       if (detail?.itemToStringValue !== undefined) {
         itemToStringValue = detail.itemToStringValue;
+        collection.setItemToStringValue(itemToStringValue);
         updateValue(currentValue, true);
       }
     })
@@ -969,6 +758,7 @@ export function createCombobox(
     close: () => updateOpenState(false),
     setItemToStringValue: (nextItemToStringValue: ComboboxItemToStringValue | null) => {
       itemToStringValue = nextItemToStringValue;
+      collection.setItemToStringValue(itemToStringValue);
       updateValue(currentValue, true);
     },
     destroy: () => {

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -1,14 +1,8 @@
 import {
   getPart,
   getParts,
-  getRoots,
   containsWithPortals,
-  getDataBool,
-  getDataNumber,
-  getDataString,
-  getDataEnum,
   reuseRootBinding,
-  hasRootBinding,
   setRootBinding,
   clearRootBinding,
   setAria,
@@ -24,82 +18,26 @@ import {
   createPresenceLifecycle,
   createDismissLayer,
 } from "@data-slot/core";
+import type {
+  ComboboxController,
+  ComboboxItemToStringValue,
+  ComboboxOptions,
+  Side,
+} from "./types";
+import { resolveComboboxConfiguration } from "./configuration";
+import { discoverComboboxes } from "./discovery";
 
-/** Side of the input to place the content */
-export type Side = "top" | "bottom";
-const SIDES = ["top", "bottom"] as const;
+export type {
+  Align,
+  ComboboxController,
+  ComboboxItemToStringValue,
+  ComboboxOptions,
+  Side,
+} from "./types";
 
-/** Alignment of the content relative to the input */
-export type Align = "start" | "center" | "end";
-const ALIGNS = ["start", "center", "end"] as const;
-
-export type ComboboxItemToStringValue = (item: HTMLElement | null, value: string | null) => string;
-
-export interface ComboboxOptions {
-  /** Initial selected value */
-  defaultValue?: string;
-  /** Callback when value changes */
-  onValueChange?: (value: string | null) => void;
-  /** Initial open state */
-  defaultOpen?: boolean;
-  /** Callback when open state changes */
-  onOpenChange?: (open: boolean) => void;
-  /** Callback when user types in the input (not on programmatic syncs) */
-  onInputValueChange?: (inputValue: string) => void;
-  /** Placeholder text for the input */
-  placeholder?: string;
-  /** Disable interaction */
-  disabled?: boolean;
-  /** Form validation required */
-  required?: boolean;
-  /** Form field name (auto-creates hidden input) */
-  name?: string;
-  /** Open popup when input receives focus @default true */
-  openOnFocus?: boolean;
-  /** Auto-highlight first visible item when filtering @default false */
-  autoHighlight?: boolean;
-  /** Custom filter function. Return true to show item. */
-  filter?: (inputValue: string, itemValue: string, itemLabel: string) => boolean;
-  /** Custom text resolver for committed selected-value text (input in inline mode, combobox-value in popup-input mode) */
-  itemToStringValue?: ComboboxItemToStringValue;
-
-  // Positioning props
-  /** @default "bottom" */
-  side?: Side;
-  /** @default "start" */
-  align?: Align;
-  /** @default 4 */
-  sideOffset?: number;
-  /** @default 0 */
-  alignOffset?: number;
-  /** @default true */
-  avoidCollisions?: boolean;
-  /** @default 8 */
-  collisionPadding?: number;
-}
-
-export interface ComboboxController {
-  /** Current selected value */
-  readonly value: string | null;
-  /** Current input text */
-  readonly inputValue: string;
-  /** Current open state */
-  readonly isOpen: boolean;
-  /** Select a value programmatically */
-  select(value: string): void;
-  /** Clear selected value */
-  clear(): void;
-  /** Open the popup */
-  open(): void;
-  /** Close the popup */
-  close(): void;
-  /** Set or clear runtime selected-value text resolver */
-  setItemToStringValue(itemToStringValue: ComboboxItemToStringValue | null): void;
-  /** Cleanup all event listeners */
-  destroy(): void;
-}
 
 const ROOT_BINDING_KEY = "@data-slot/combobox";
+const SIDES = ["top", "bottom"] as const;
 const DUPLICATE_BINDING_WARNING =
   "[@data-slot/combobox] createCombobox() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
 
@@ -152,59 +90,12 @@ export function createCombobox(
   const valueSlotPlaceholder = valueSlot?.textContent?.trim() ?? "";
 
   // Resolve options: JS > data-* > defaults
-  const defaultValue = options.defaultValue ?? getDataString(root, "defaultValue") ?? null;
-  const defaultOpen = options.defaultOpen ?? getDataBool(root, "defaultOpen") ?? false;
-  const placeholder = options.placeholder ?? getDataString(root, "placeholder") ?? "";
-  const disabled = options.disabled ?? getDataBool(root, "disabled") ?? false;
-  const required = options.required ?? getDataBool(root, "required") ?? false;
-  const name = options.name ?? getDataString(root, "name") ?? null;
-  const openOnFocus = options.openOnFocus ?? getDataBool(root, "openOnFocus") ?? true;
-  const autoHighlight = options.autoHighlight ?? getDataBool(root, "autoHighlight") ?? false;
-  const customFilter = options.filter ?? null;
-  const onValueChange = options.onValueChange;
-  const onOpenChange = options.onOpenChange;
-  const onInputValueChange = options.onInputValueChange;
+  const {
+    defaultValue, defaultOpen, placeholder, disabled, required, name, openOnFocus, autoHighlight,
+    customFilter, onValueChange, onOpenChange, onInputValueChange, preferredSide, preferredAlign,
+    sideOffset, alignOffset, avoidCollisions, collisionPadding,
+  } = resolveComboboxConfiguration(root, content, authoredPositioner, options);
   let itemToStringValue = options.itemToStringValue ?? null;
-
-  // Placement precedence: JS option > content > authored positioner > root
-  const getPlacementEnum = <T extends string>(key: string, allowed: readonly T[]): T | undefined =>
-    getDataEnum(content, key, allowed) ??
-    (authoredPositioner ? getDataEnum(authoredPositioner, key, allowed) : undefined) ??
-    getDataEnum(root, key, allowed);
-  const getPlacementNumber = (key: string): number | undefined =>
-    getDataNumber(content, key) ??
-    (authoredPositioner ? getDataNumber(authoredPositioner, key) : undefined) ??
-    getDataNumber(root, key);
-  const getPlacementBool = (key: string): boolean | undefined =>
-    getDataBool(content, key) ??
-    (authoredPositioner ? getDataBool(authoredPositioner, key) : undefined) ??
-    getDataBool(root, key);
-
-  // Positioning options
-  const preferredSide =
-    options.side ??
-    getPlacementEnum("side", SIDES) ??
-    "bottom";
-  const preferredAlign =
-    options.align ??
-    getPlacementEnum("align", ALIGNS) ??
-    "start";
-  const sideOffset =
-    options.sideOffset ??
-    getPlacementNumber("sideOffset") ??
-    4;
-  const alignOffset =
-    options.alignOffset ??
-    getPlacementNumber("alignOffset") ??
-    0;
-  const avoidCollisions =
-    options.avoidCollisions ??
-    getPlacementBool("avoidCollisions") ??
-    true;
-  const collisionPadding =
-    options.collisionPadding ??
-    getPlacementNumber("collisionPadding") ??
-    8;
 
   // State
   let isOpen = false;
@@ -1100,15 +991,6 @@ export function createCombobox(
   return controller;
 }
 
-/**
- * Find and bind all combobox components in a scope
- * Returns array of controllers for programmatic access
- */
 export function create(scope: ParentNode = document): ComboboxController[] {
-  const controllers: ComboboxController[] = [];
-  for (const root of getRoots(scope, "combobox")) {
-    if (hasRootBinding(root, ROOT_BINDING_KEY)) continue;
-    controllers.push(createCombobox(root));
-  }
-  return controllers;
+  return discoverComboboxes(scope, createCombobox);
 }

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -467,7 +467,7 @@ export function createCombobox(
   };
 
   const selectItem = (item: HTMLElement) => {
-    if (collection.indexOf(item) === undefined) return;
+    if (collection.isDisabled(item)) return;
     const value = collection.valueOf(item);
     if (value === undefined) return;
 

--- a/packages/combobox/src/types.ts
+++ b/packages/combobox/src/types.ts
@@ -1,41 +1,71 @@
-/** Side of the input to place the content. */
+/** Side of the input to place the content */
 export type Side = "top" | "bottom";
 
-/** Alignment of the content relative to the input. */
+/** Alignment of the content relative to the input */
 export type Align = "start" | "center" | "end";
 
 export type ComboboxItemToStringValue = (item: HTMLElement | null, value: string | null) => string;
 
 export interface ComboboxOptions {
+  /** Initial selected value */
   defaultValue?: string;
+  /** Callback when value changes */
   onValueChange?: (value: string | null) => void;
+  /** Initial open state */
   defaultOpen?: boolean;
+  /** Callback when open state changes */
   onOpenChange?: (open: boolean) => void;
+  /** Callback when user types in the input (not on programmatic syncs) */
   onInputValueChange?: (inputValue: string) => void;
+  /** Placeholder text for the input */
   placeholder?: string;
+  /** Disable interaction */
   disabled?: boolean;
+  /** Form validation required */
   required?: boolean;
+  /** Form field name (auto-creates hidden input) */
   name?: string;
+  /** Open popup when input receives focus @default true */
   openOnFocus?: boolean;
+  /** Auto-highlight first visible item when filtering @default false */
   autoHighlight?: boolean;
+  /** Custom filter function. Return true to show item. */
   filter?: (inputValue: string, itemValue: string, itemLabel: string) => boolean;
+  /** Custom text resolver for committed selected-value text (input in inline mode, combobox-value in popup-input mode) */
   itemToStringValue?: ComboboxItemToStringValue;
+
+  // Positioning props
+  /** @default "bottom" */
   side?: Side;
+  /** @default "start" */
   align?: Align;
+  /** @default 4 */
   sideOffset?: number;
+  /** @default 0 */
   alignOffset?: number;
+  /** @default true */
   avoidCollisions?: boolean;
+  /** @default 8 */
   collisionPadding?: number;
 }
 
 export interface ComboboxController {
+  /** Current selected value */
   readonly value: string | null;
+  /** Current input text */
   readonly inputValue: string;
+  /** Current open state */
   readonly isOpen: boolean;
+  /** Select a value programmatically */
   select(value: string): void;
+  /** Clear selected value */
   clear(): void;
+  /** Open the popup */
   open(): void;
+  /** Close the popup */
   close(): void;
+  /** Set or clear runtime selected-value text resolver */
   setItemToStringValue(itemToStringValue: ComboboxItemToStringValue | null): void;
+  /** Cleanup all event listeners */
   destroy(): void;
 }

--- a/packages/combobox/src/types.ts
+++ b/packages/combobox/src/types.ts
@@ -1,0 +1,41 @@
+/** Side of the input to place the content. */
+export type Side = "top" | "bottom";
+
+/** Alignment of the content relative to the input. */
+export type Align = "start" | "center" | "end";
+
+export type ComboboxItemToStringValue = (item: HTMLElement | null, value: string | null) => string;
+
+export interface ComboboxOptions {
+  defaultValue?: string;
+  onValueChange?: (value: string | null) => void;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onInputValueChange?: (inputValue: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  name?: string;
+  openOnFocus?: boolean;
+  autoHighlight?: boolean;
+  filter?: (inputValue: string, itemValue: string, itemLabel: string) => boolean;
+  itemToStringValue?: ComboboxItemToStringValue;
+  side?: Side;
+  align?: Align;
+  sideOffset?: number;
+  alignOffset?: number;
+  avoidCollisions?: boolean;
+  collisionPadding?: number;
+}
+
+export interface ComboboxController {
+  readonly value: string | null;
+  readonly inputValue: string;
+  readonly isOpen: boolean;
+  select(value: string): void;
+  clear(): void;
+  open(): void;
+  close(): void;
+  setItemToStringValue(itemToStringValue: ComboboxItemToStringValue | null): void;
+  destroy(): void;
+}

--- a/packages/command/src/command-collection-model.ts
+++ b/packages/command/src/command-collection-model.ts
@@ -1,0 +1,77 @@
+/** DOM ownership and value resolution for a command collection. */
+export interface CommandGroupMeta {
+  el: HTMLElement;
+  heading: HTMLElement | null;
+  value: string;
+  forceMount: boolean;
+  maxRank: number;
+}
+
+export interface CommandItemMeta {
+  el: HTMLElement;
+  value: string | null;
+  keywords: string[];
+  disabled: boolean;
+  forceMount: boolean;
+  rank: number;
+  group: CommandGroupMeta | null;
+}
+
+const AUTHORED_VALUE_SYMBOL = Symbol("data-slot.command.authored-value");
+const INFERRED_VALUE_SYMBOL = Symbol("data-slot.command.inferred-value");
+
+export const normalizeCommandValue = (value: string | null | undefined): string | null =>
+  value == null ? null : value.trim();
+
+export const parseCommandKeywords = (value: string | undefined): string[] =>
+  value
+    ? value.split(/[,\n]/).map((part) => part.trim()).filter(Boolean)
+    : [];
+
+export const getOwnedCommandElements = <T extends HTMLElement>(
+  scope: ParentNode,
+  selector: string,
+  root: HTMLElement,
+): T[] => Array.from(scope.querySelectorAll<T>(selector)).filter((el) => el.closest('[data-slot="command"]') === root);
+
+export const getDirectCommandChildren = <T extends HTMLElement>(parent: HTMLElement, slot: string): T[] =>
+  Array.from(parent.children).filter(
+    (child): child is T => child instanceof HTMLElement && child.getAttribute("data-slot") === slot,
+  );
+
+export const getCommandItemText = (item: HTMLElement): string => {
+  const collectText = (node: Node): string => {
+    if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+    if (!(node instanceof HTMLElement) || node.getAttribute("data-slot") === "command-shortcut") return "";
+    return Array.from(node.childNodes, collectText).join("");
+  };
+  return collectText(item).replace(/\s+/g, " ").trim();
+};
+
+export const isCommandItemDisabled = (el: HTMLElement): boolean =>
+  el.hasAttribute("disabled") || el.hasAttribute("data-disabled") || el.getAttribute("aria-disabled") === "true";
+
+type CommandTaggedElement = HTMLElement & {
+  [AUTHORED_VALUE_SYMBOL]?: boolean;
+  [INFERRED_VALUE_SYMBOL]?: string | null;
+};
+
+/** Keeps authored values stable while refreshing inferred text values after DOM mutations. */
+export const resolveCommandValue = (
+  el: HTMLElement,
+  fallback: () => string | null,
+): { authored: boolean; value: string | null } => {
+  const tagged = el as CommandTaggedElement;
+  const hasDataValue = el.hasAttribute("data-value");
+  if (tagged[AUTHORED_VALUE_SYMBOL] === undefined) tagged[AUTHORED_VALUE_SYMBOL] = hasDataValue;
+  if (!hasDataValue) tagged[AUTHORED_VALUE_SYMBOL] = false;
+  else if (!tagged[AUTHORED_VALUE_SYMBOL]) {
+    tagged[AUTHORED_VALUE_SYMBOL] = normalizeCommandValue(el.getAttribute("data-value")) !== tagged[INFERRED_VALUE_SYMBOL];
+  }
+  if (tagged[AUTHORED_VALUE_SYMBOL]) return { authored: true, value: normalizeCommandValue(el.getAttribute("data-value")) };
+  const value = fallback();
+  tagged[INFERRED_VALUE_SYMBOL] = value;
+  if (value === null) el.removeAttribute("data-value");
+  else el.setAttribute("data-value", value);
+  return { authored: false, value };
+};

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -14,9 +14,18 @@ import {
   ensureItemVisibleInContainer,
 } from "@data-slot/core";
 import { commandScore } from "./command-score";
-
+import {
+  getCommandItemText,
+  getDirectCommandChildren,
+  getOwnedCommandElements,
+  isCommandItemDisabled,
+  normalizeCommandValue,
+  parseCommandKeywords,
+  resolveCommandValue,
+  type CommandGroupMeta,
+  type CommandItemMeta,
+} from "./command-collection-model";
 export type CommandFilter = (value: string, search: string, keywords?: string[]) => number;
-
 export interface CommandOptions {
   /** Accessible label announced for the command input */
   label?: string;
@@ -41,7 +50,6 @@ export interface CommandOptions {
   /** Enable ctrl+j/k/n/p shortcuts @default true */
   vimBindings?: boolean;
 }
-
 export interface CommandController {
   /** Current active item value */
   readonly value: string | null;
@@ -54,40 +62,18 @@ export interface CommandController {
   /** Cleanup all event listeners and observers */
   destroy(): void;
 }
-
-interface GroupMeta {
-  el: HTMLElement;
-  heading: HTMLElement | null;
-  value: string;
-  forceMount: boolean;
-  maxRank: number;
-}
-
-interface ItemMeta {
-  el: HTMLElement;
-  value: string | null;
-  keywords: string[];
-  disabled: boolean;
-  forceMount: boolean;
-  rank: number;
-  group: GroupMeta | null;
-}
-
+type GroupMeta = CommandGroupMeta;
+type ItemMeta = CommandItemMeta;
 interface SetValueOptions {
   emit?: boolean;
   ensureVisible?: boolean;
 }
-
 const ROOT_BINDING_KEY = "@data-slot/command";
 const DUPLICATE_BINDING_WARNING =
   "[@data-slot/command] createCommand() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
-
 const ITEM_SELECTOR = '[data-slot="command-item"]';
 const GROUP_SELECTOR = '[data-slot="command-group"]';
-const GROUP_HEADING_SELECTOR = '[data-slot="command-group-heading"]';
 const SEPARATOR_SELECTOR = '[data-slot="command-separator"]';
-const AUTHORED_VALUE_SYMBOL = Symbol("data-slot.command.authored-value");
-const INFERRED_VALUE_SYMBOL = Symbol("data-slot.command.inferred-value");
 const DIRECT_MUTATION_ATTRIBUTES = [
   "data-slot",
   "data-value",
@@ -112,28 +98,10 @@ const INTERACTIVE_DESCENDANT_SELECTOR = [
   '[contenteditable="plaintext-only"]',
   '[tabindex]:not([tabindex="-1"])',
 ].join(", ");
-
 const defaultFilter: CommandFilter = (value, search, keywords) => {
   if (!search.trim()) return 1;
   return commandScore(value, search, keywords ?? []);
 };
-
-const normalizeValue = (value: string | null | undefined): string | null =>
-  value == null ? null : value.trim();
-
-const parseKeywords = (value: string | undefined): string[] => {
-  if (!value) return [];
-  return value
-    .split(/[,\n]/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-};
-
-const getDirectChildrenBySlot = <T extends HTMLElement>(parent: HTMLElement, slot: string): T[] =>
-  Array.from(parent.children).filter(
-    (child): child is T => child instanceof HTMLElement && child.getAttribute("data-slot") === slot
-  );
-
 const getDirectChildWithinContainer = (el: HTMLElement, container: HTMLElement): HTMLElement | null => {
   let current: HTMLElement | null = el;
   while (current && current.parentElement && current.parentElement !== container) {
@@ -141,88 +109,8 @@ const getDirectChildWithinContainer = (el: HTMLElement, container: HTMLElement):
   }
   return current?.parentElement === container ? current : null;
 };
-
-const getOwnedElements = <T extends HTMLElement>(
-  scope: ParentNode,
-  selector: string,
-  root: HTMLElement
-): T[] =>
-  Array.from(scope.querySelectorAll<T>(selector)).filter(
-    (el) => el.closest('[data-slot="command"]') === root
-  );
-
 const getElementChildren = (container: HTMLElement): HTMLElement[] =>
   Array.from(container.children).filter((child): child is HTMLElement => child instanceof HTMLElement);
-
-const getItemText = (item: HTMLElement): string => {
-  const collectText = (node: Node): string => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      return node.textContent ?? "";
-    }
-    if (!(node instanceof HTMLElement)) {
-      return "";
-    }
-    const slot = node.getAttribute("data-slot");
-    if (slot === "command-shortcut") {
-      return "";
-    }
-
-    let text = "";
-    for (const child of node.childNodes) {
-      text += collectText(child);
-    }
-    return text;
-  };
-
-  return collectText(item).replace(/\s+/g, " ").trim();
-};
-
-const isItemDisabled = (el: HTMLElement): boolean =>
-  el.hasAttribute("disabled") || el.hasAttribute("data-disabled") || el.getAttribute("aria-disabled") === "true";
-
-type CommandTaggedElement = HTMLElement & {
-  [AUTHORED_VALUE_SYMBOL]?: boolean;
-  [INFERRED_VALUE_SYMBOL]?: string | null;
-};
-
-const resolveValueSource = (
-  el: HTMLElement,
-  fallback: () => string | null
-): { authored: boolean; value: string | null } => {
-  const tagged = el as CommandTaggedElement;
-  const hasDataValue = el.hasAttribute("data-value");
-
-  if (tagged[AUTHORED_VALUE_SYMBOL] === undefined) {
-    tagged[AUTHORED_VALUE_SYMBOL] = hasDataValue;
-  }
-
-  if (!hasDataValue) {
-    tagged[AUTHORED_VALUE_SYMBOL] = false;
-  } else if (!tagged[AUTHORED_VALUE_SYMBOL]) {
-    const authoredOverride = normalizeValue(el.getAttribute("data-value")) !== tagged[INFERRED_VALUE_SYMBOL];
-    if (authoredOverride) {
-      tagged[AUTHORED_VALUE_SYMBOL] = true;
-    }
-  }
-
-  if (tagged[AUTHORED_VALUE_SYMBOL]) {
-    return {
-      authored: true,
-      value: normalizeValue(el.getAttribute("data-value")),
-    };
-  }
-
-  const value = fallback();
-  tagged[INFERRED_VALUE_SYMBOL] = value;
-  if (value === null) {
-    el.removeAttribute("data-value");
-  } else {
-    el.setAttribute("data-value", value);
-  }
-
-  return { authored: false, value };
-};
-
 export function createCommand(
   root: Element,
   options: CommandOptions = {}
@@ -233,16 +121,13 @@ export function createCommand(
     DUPLICATE_BINDING_WARNING
   );
   if (existingController) return existingController;
-
   const rootEl = root as HTMLElement;
   const input = getPart<HTMLInputElement>(root, "command-input");
   const list = getPart<HTMLElement>(root, "command-list");
   const empty = getPart<HTMLElement>(list ?? root, "command-empty");
-
   if (!input || !list) {
     throw new Error("Command requires command-input and command-list slots");
   }
-
   const label = options.label ?? getDataString(rootEl, "label") ?? "Command Menu";
   const shouldFilter = options.shouldFilter ?? getDataBool(rootEl, "shouldFilter") ?? true;
   const loop = options.loop ?? getDataBool(rootEl, "loop") ?? false;
@@ -253,8 +138,7 @@ export function createCommand(
   const onValueChange = options.onValueChange;
   const onSearchChange = options.onSearchChange;
   const onSelect = options.onSelect;
-
-  let currentValue = normalizeValue(options.defaultValue ?? getDataString(rootEl, "defaultValue"));
+  let currentValue = normalizeCommandValue(options.defaultValue ?? getDataString(rootEl, "defaultValue"));
   let currentSearch = options.defaultSearch ?? getDataString(rootEl, "defaultSearch") ?? "";
   let itemMetas: ItemMeta[] = [];
   let groupMetas: GroupMeta[] = [];
@@ -270,15 +154,12 @@ export function createCommand(
   let authoredListChildren: HTMLElement[] = [];
   let authoredGroupChildren = new Map<HTMLElement, HTMLElement[]>();
   let layoutIsRanked = false;
-
   const inputId = ensureId(input, "command-input");
   const listId = ensureId(list, "command-list");
-
   if (!rootEl.hasAttribute("tabindex")) {
     rootEl.tabIndex = -1;
     addedRootTabIndex = true;
   }
-
   input.setAttribute("role", "combobox");
   input.setAttribute("aria-autocomplete", "list");
   input.setAttribute("aria-expanded", "true");
@@ -286,10 +167,8 @@ export function createCommand(
   input.setAttribute("autocomplete", "off");
   input.setAttribute("autocorrect", "off");
   input.spellcheck = false;
-
   list.setAttribute("role", "listbox");
   list.tabIndex = -1;
-
   const nativeLabel = document.querySelector<HTMLLabelElement>(`label[for="${CSS.escape(inputId)}"]`);
   if (nativeLabel) {
     const labelId = ensureId(nativeLabel, "command-label");
@@ -300,18 +179,15 @@ export function createCommand(
     input.setAttribute("aria-label", label);
     list.setAttribute("aria-label", "Suggestions");
   }
-
   const focusInput = () => {
     if (document.activeElement === input) return;
     input.focus({ preventScroll: true });
   };
-
   const getInteractiveDescendant = (target: EventTarget | null): HTMLElement | null => {
     if (!(target instanceof HTMLElement) || !rootEl.contains(target)) return null;
     const interactive = target.closest(INTERACTIVE_DESCENDANT_SELECTOR);
     return interactive instanceof HTMLElement && rootEl.contains(interactive) ? interactive : null;
   };
-
   const pauseMutationObserver = <T>(fn: () => T): T => {
     mutationObserver?.disconnect();
     try {
@@ -320,46 +196,36 @@ export function createCommand(
       observeMutations();
     }
   };
-
   const setListHeightVar = () => {
     list.style.setProperty("--command-list-height", `${list.scrollHeight.toFixed(1)}px`);
   };
-
   const syncResizeObserver = () => {
     if (typeof ResizeObserver === "undefined") {
       setListHeightVar();
       return;
     }
-
     if (!resizeObserver) {
       resizeObserver = new ResizeObserver(() => {
         setListHeightVar();
       });
     }
-
     resizeObserver.disconnect();
     resizeObserver.observe(list);
-
-    for (const el of getOwnedElements<HTMLElement>(
+    for (const el of getOwnedCommandElements<HTMLElement>(
       list,
       `${ITEM_SELECTOR}, ${GROUP_SELECTOR}, ${SEPARATOR_SELECTOR}, [data-slot="command-empty"]`,
       rootEl
     )) {
       resizeObserver.observe(el);
     }
-
     setListHeightVar();
   };
-
   const mergeChildOrder = (snapshot: HTMLElement[], currentChildren: HTMLElement[]): HTMLElement[] => {
     const next = snapshot.filter((child) => currentChildren.includes(child));
-
     for (const child of currentChildren) {
       if (next.includes(child)) continue;
-
       const currentIndex = currentChildren.indexOf(child);
       let inserted = false;
-
       for (let index = currentIndex - 1; index >= 0; index -= 1) {
         const previousSibling = currentChildren[index];
         if (!previousSibling) continue;
@@ -370,9 +236,7 @@ export function createCommand(
           break;
         }
       }
-
       if (inserted) continue;
-
       for (let index = currentIndex + 1; index < currentChildren.length; index += 1) {
         const nextSibling = currentChildren[index];
         if (!nextSibling) continue;
@@ -383,29 +247,24 @@ export function createCommand(
           break;
         }
       }
-
       if (!inserted) {
         next.push(child);
       }
     }
-
     return next;
   };
-
   const captureAuthoredStructure = () => {
     authoredListChildren = getElementChildren(list);
     authoredGroupChildren = new Map(
       groupMetas.map((group) => [group.el, getElementChildren(group.el)])
     );
   };
-
   const mergeAuthoredStructure = () => {
     const currentListChildren = getElementChildren(list);
     authoredListChildren =
       authoredListChildren.length === 0
         ? currentListChildren
         : mergeChildOrder(authoredListChildren, currentListChildren);
-
     const nextGroupChildren = new Map<HTMLElement, HTMLElement[]>();
     for (const group of groupMetas) {
       const currentChildren = getElementChildren(group.el);
@@ -417,43 +276,35 @@ export function createCommand(
           : mergeChildOrder(existingSnapshot, currentChildren)
       );
     }
-
     authoredGroupChildren = nextGroupChildren;
   };
-
   const applyChildOrder = (container: HTMLElement, orderedChildren: HTMLElement[]) => {
     const currentChildren = getElementChildren(container);
     const placedChildren = new Set<HTMLElement>();
-
     for (const child of orderedChildren) {
       if (child.parentElement !== container || placedChildren.has(child)) continue;
       placedChildren.add(child);
       container.appendChild(child);
     }
-
     for (const child of currentChildren) {
       if (placedChildren.has(child) || child.parentElement !== container) continue;
       container.appendChild(child);
     }
   };
-
   const getOrderIndexMap = (snapshot: HTMLElement[]) =>
     new Map(snapshot.map((el, index) => [el, index]));
-
   const restoreAuthoredOrder = () => {
     for (const group of groupMetas) {
       const groupChildren =
         authoredGroupChildren.get(group.el)?.filter((child) => child.parentElement === group.el) ?? [];
       applyChildOrder(group.el, groupChildren);
     }
-
     const listChildren = authoredListChildren.filter((child) => child.parentElement === list);
     applyChildOrder(list, listChildren);
   };
-
   const getSelectedVisibleItem = (): HTMLElement | null => {
     if (currentValue === null) return null;
-    const items = getOwnedElements<HTMLElement>(list, ITEM_SELECTOR, rootEl);
+    const items = getOwnedCommandElements<HTMLElement>(list, ITEM_SELECTOR, rootEl);
     return (
       items.find((item) => {
         const meta = itemMetaByElement.get(item);
@@ -461,7 +312,6 @@ export function createCommand(
       }) ?? null
     );
   };
-
   const syncSelectionState = () => {
     for (const meta of itemMetas) {
       const selected = meta.value === currentValue && currentValue !== null;
@@ -472,7 +322,6 @@ export function createCommand(
         meta.el.removeAttribute("data-selected");
       }
     }
-
     const selectedVisible = getSelectedVisibleItem();
     if (selectedVisible) {
       input.setAttribute("aria-activedescendant", selectedVisible.id);
@@ -482,46 +331,39 @@ export function createCommand(
       list.removeAttribute("aria-activedescendant");
     }
   };
-
   const syncRootState = () => {
     if (currentValue !== null) {
       rootEl.setAttribute("data-value", currentValue);
     } else {
       rootEl.removeAttribute("data-value");
     }
-
     if (currentSearch) {
       rootEl.setAttribute("data-search", currentSearch);
     } else {
       rootEl.removeAttribute("data-search");
     }
   };
-
   const getAllVisibleItemsInDomOrder = (): ItemMeta[] =>
-    getOwnedElements<HTMLElement>(list, ITEM_SELECTOR, rootEl)
+    getOwnedCommandElements<HTMLElement>(list, ITEM_SELECTOR, rootEl)
       .map((el) => itemMetaByElement.get(el) ?? null)
       .filter(
         (meta): meta is ItemMeta =>
           meta !== null && !meta.el.hidden && !(meta.group?.el.hidden ?? false)
       );
-
   const getEnabledVisibleItemsInDomOrder = (): ItemMeta[] =>
     getAllVisibleItemsInDomOrder().filter((meta) => !meta.disabled);
-
   const emitValueIfChanged = (previousValue: string | null, nextValue: string | null, shouldEmit: boolean) => {
     if (!shouldEmit || previousValue === nextValue) return;
     emit(rootEl, "command:change", { value: nextValue });
     onValueChange?.(nextValue);
   };
-
   const scrollSelectedItemIntoView = () => {
     const selectedVisible = getSelectedVisibleItem();
     if (!selectedVisible) return;
     ensureItemVisibleInContainer(selectedVisible, list);
   };
-
   const setValue = (nextValue: string | null, options: SetValueOptions = {}): boolean => {
-    const normalized = normalizeValue(nextValue);
+    const normalized = normalizeCommandValue(nextValue);
     const previousValue = currentValue;
     const shouldEmit = options.emit ?? true;
     const shouldEnsureVisible = options.ensureVisible ?? false;
@@ -537,18 +379,16 @@ export function createCommand(
     emitValueIfChanged(previousValue, currentValue, shouldEmit);
     return previousValue !== currentValue;
   };
-
   const rescanStructure = () => {
     itemMetas = [];
     groupMetas = [];
     itemMetaByElement = new Map();
     groupMetaByElement = new Map();
-
-    for (const groupEl of getOwnedElements<HTMLElement>(list, GROUP_SELECTOR, rootEl)) {
-      const heading = getDirectChildrenBySlot<HTMLElement>(groupEl, "command-group-heading")[0] ?? null;
-      const resolved = resolveValueSource(
+    for (const groupEl of getOwnedCommandElements<HTMLElement>(list, GROUP_SELECTOR, rootEl)) {
+      const heading = getDirectCommandChildren<HTMLElement>(groupEl, "command-group-heading")[0] ?? null;
+      const resolved = resolveCommandValue(
         groupEl,
-        () => normalizeValue(heading?.textContent) ?? ensureId(groupEl, "command-group")
+        () => normalizeCommandValue(heading?.textContent) ?? ensureId(groupEl, "command-group")
       );
       const meta: GroupMeta = {
         el: groupEl,
@@ -557,10 +397,8 @@ export function createCommand(
         forceMount: getDataBool(groupEl, "forceMount") ?? false,
         maxRank: 0,
       };
-
       groupMetaByElement.set(groupEl, meta);
       groupMetas.push(meta);
-
       groupEl.setAttribute("role", "group");
       if (heading) {
         const headingId = ensureId(heading, "command-group-heading");
@@ -569,30 +407,27 @@ export function createCommand(
         groupEl.removeAttribute("aria-labelledby");
       }
     }
-
-    for (const itemEl of getOwnedElements<HTMLElement>(list, ITEM_SELECTOR, rootEl)) {
+    for (const itemEl of getOwnedCommandElements<HTMLElement>(list, ITEM_SELECTOR, rootEl)) {
       const groupEl = itemEl.closest(GROUP_SELECTOR);
       const group =
         groupEl instanceof HTMLElement && groupEl.closest('[data-slot="command"]') === rootEl
           ? groupMetaByElement.get(groupEl) ?? null
           : null;
-      const resolved = resolveValueSource(
+      const resolved = resolveCommandValue(
         itemEl,
-        () => normalizeValue(itemEl.getAttribute("data-label")) ?? normalizeValue(getItemText(itemEl))
+        () => normalizeCommandValue(itemEl.getAttribute("data-label")) ?? normalizeCommandValue(getCommandItemText(itemEl))
       );
       const meta: ItemMeta = {
         el: itemEl,
         value: resolved.value,
-        keywords: parseKeywords(itemEl.getAttribute("data-keywords") ?? undefined),
-        disabled: isItemDisabled(itemEl),
+        keywords: parseCommandKeywords(itemEl.getAttribute("data-keywords") ?? undefined),
+        disabled: isCommandItemDisabled(itemEl),
         forceMount: getDataBool(itemEl, "forceMount") ?? false,
         rank: 0,
         group,
       };
-
       itemMetaByElement.set(itemEl, meta);
       itemMetas.push(meta);
-
       ensureId(itemEl, "command-item");
       itemEl.setAttribute("role", "option");
       if (meta.disabled) {
@@ -602,41 +437,32 @@ export function createCommand(
       }
     }
   };
-
   const applyVisibilityState = () => {
     const hasSearch = currentSearch.length > 0;
     filteredCount = 0;
-
     for (const group of groupMetas) {
       group.maxRank = 0;
     }
-
     for (const meta of itemMetas) {
       meta.rank =
         shouldFilter && hasSearch && meta.value !== null ? filter(meta.value, currentSearch, meta.keywords) : 1;
-
       if (shouldFilter && hasSearch && meta.rank > 0) {
         filteredCount += 1;
       }
-
       const visible =
         !hasSearch ||
         !shouldFilter ||
         meta.forceMount ||
         meta.group?.forceMount ||
         meta.rank > 0;
-
       meta.el.hidden = !visible;
-
       if (meta.group && meta.rank > meta.group.maxRank) {
         meta.group.maxRank = meta.rank;
       }
     }
-
     if (!shouldFilter || !hasSearch) {
       filteredCount = itemMetas.length;
     }
-
     for (const group of groupMetas) {
       const visible =
         !hasSearch ||
@@ -645,43 +471,34 @@ export function createCommand(
         itemMetas.some((meta) => meta.group === group && meta.rank > 0);
       group.el.hidden = !visible;
     }
-
-    for (const separator of getOwnedElements<HTMLElement>(list, SEPARATOR_SELECTOR, rootEl)) {
+    for (const separator of getOwnedCommandElements<HTMLElement>(list, SEPARATOR_SELECTOR, rootEl)) {
       const alwaysRender = getDataBool(separator, "alwaysRender") ?? false;
       separator.hidden = hasSearch && !alwaysRender;
       separator.setAttribute("role", "separator");
     }
-
     if (empty) {
       empty.hidden = filteredCount > 0;
     }
   };
-
   const sortVisibleBlocks = () => {
     if (!shouldFilter || !currentSearch) return;
-
     const authoredListSnapshot = authoredListChildren.filter((child) => child.parentElement === list);
     const listOrderIndex = getOrderIndexMap(authoredListSnapshot);
-
     const topLevelItemBlocks = new Map<HTMLElement, number>();
     const topLevelVisibleItemBlocks = new Map<HTMLElement, number>();
-
     for (const meta of itemMetas) {
       if (meta.group !== null) continue;
       const block = getDirectChildWithinContainer(meta.el, list);
       if (!block) continue;
-
       topLevelItemBlocks.set(block, Math.max(topLevelItemBlocks.get(block) ?? 0, meta.rank));
       if (!meta.el.hidden) {
         topLevelVisibleItemBlocks.set(block, Math.max(topLevelVisibleItemBlocks.get(block) ?? 0, meta.rank));
       }
     }
-
     const allTopLevelBlocks = new Set<HTMLElement>([
       ...topLevelItemBlocks.keys(),
       ...groupMetas.map((group) => group.el),
     ]);
-
     const visibleTopLevelBlocks = [
       ...Array.from(topLevelVisibleItemBlocks, ([el, rank]) => ({ el, rank })),
       ...groupMetas
@@ -691,7 +508,6 @@ export function createCommand(
       if (b.rank !== a.rank) return b.rank - a.rank;
       return (listOrderIndex.get(a.el) ?? Number.MAX_SAFE_INTEGER) - (listOrderIndex.get(b.el) ?? Number.MAX_SAFE_INTEGER);
     });
-
     const visibleTopLevelSet = new Set(visibleTopLevelBlocks.map((block) => block.el));
     const hiddenTopLevelBlocks = authoredListSnapshot.filter(
       (child) => allTopLevelBlocks.has(child) && !visibleTopLevelSet.has(child)
@@ -700,38 +516,32 @@ export function createCommand(
       ...visibleTopLevelBlocks.map((block) => block.el),
       ...hiddenTopLevelBlocks,
     ];
-
     let topLevelBlockIndex = 0;
     const nextListOrder = authoredListSnapshot.map((child) =>
       allTopLevelBlocks.has(child) ? rankedTopLevelBlocks[topLevelBlockIndex++] ?? child : child
     );
     applyChildOrder(list, nextListOrder);
-
     for (const group of groupMetas) {
       const authoredGroupSnapshot =
         authoredGroupChildren.get(group.el)?.filter((child) => child.parentElement === group.el) ?? [];
       const groupOrderIndex = getOrderIndexMap(authoredGroupSnapshot);
       const allGroupItemBlocks = new Set<HTMLElement>();
       const visibleGroupBlocks = new Map<HTMLElement, number>();
-
       for (const meta of itemMetas) {
         if (meta.group !== group) continue;
         const block = getDirectChildWithinContainer(meta.el, group.el);
         if (!block) continue;
-
         allGroupItemBlocks.add(block);
         if (!meta.el.hidden) {
           visibleGroupBlocks.set(block, Math.max(visibleGroupBlocks.get(block) ?? 0, meta.rank));
         }
       }
-
       const rankedVisibleGroupBlocks = Array.from(visibleGroupBlocks, ([el, rank]) => ({ el, rank })).sort(
         (a, b) => {
           if (b.rank !== a.rank) return b.rank - a.rank;
           return (groupOrderIndex.get(a.el) ?? Number.MAX_SAFE_INTEGER) - (groupOrderIndex.get(b.el) ?? Number.MAX_SAFE_INTEGER);
         }
       );
-
       const visibleGroupSet = new Set(rankedVisibleGroupBlocks.map((block) => block.el));
       const hiddenGroupBlocks = authoredGroupSnapshot.filter(
         (child) => allGroupItemBlocks.has(child) && !visibleGroupSet.has(child)
@@ -740,7 +550,6 @@ export function createCommand(
         ...rankedVisibleGroupBlocks.map((block) => block.el),
         ...hiddenGroupBlocks,
       ];
-
       let groupBlockIndex = 0;
       const nextGroupOrder = authoredGroupSnapshot.map((child) =>
         allGroupItemBlocks.has(child) ? rankedGroupBlocks[groupBlockIndex++] ?? child : child
@@ -748,7 +557,6 @@ export function createCommand(
       applyChildOrder(group.el, nextGroupOrder);
     }
   };
-
   const refreshDisplay = () => {
     pauseMutationObserver(() => {
       rescanStructure();
@@ -771,12 +579,10 @@ export function createCommand(
     observeMutations();
     syncResizeObserver();
   };
-
   const selectFirstVisibleItem = (shouldEmit = true, ensureVisible = false) => {
     const nextValue = getEnabledVisibleItemsInDomOrder()[0]?.value ?? null;
     setValue(nextValue, { emit: shouldEmit, ensureVisible });
   };
-
   const setSearchValue = (nextSearch: string, shouldEmit = true, syncFirstVisible = true) => {
     if (currentSearch === nextSearch) return;
     currentSearch = nextSearch;
@@ -790,14 +596,12 @@ export function createCommand(
       onSearchChange?.(currentSearch);
     }
   };
-
   const triggerSelection = (meta: ItemMeta) => {
     if (meta.value === null || meta.disabled) return;
     setValue(meta.value, { emit: true });
     emit(rootEl, "command:select", { value: meta.value });
     onSelect?.(meta.value);
   };
-
   const getLiveItemMeta = (item: HTMLElement): ItemMeta | null => {
     let meta = itemMetaByElement.get(item) ?? null;
     if (meta) return meta;
@@ -805,7 +609,6 @@ export function createCommand(
     meta = itemMetaByElement.get(item) ?? null;
     return meta;
   };
-
   const moveSelectionToIndex = (index: number) => {
     const items = getEnabledVisibleItemsInDomOrder();
     const meta = items[index];
@@ -813,14 +616,11 @@ export function createCommand(
       setValue(meta.value, { emit: true, ensureVisible: true });
     }
   };
-
   const moveSelectionByItem = (change: 1 | -1) => {
     const items = getEnabledVisibleItemsInDomOrder();
     if (items.length === 0) return;
-
     const currentIndex = items.findIndex((meta) => meta.value === currentValue);
     let nextMeta = items[currentIndex + change];
-
     if (loop) {
       nextMeta =
         currentIndex + change < 0
@@ -829,16 +629,13 @@ export function createCommand(
           ? items[0]
           : items[currentIndex + change];
     }
-
     if (nextMeta) {
       setValue(nextMeta.value, { emit: true, ensureVisible: true });
     }
   };
-
   const moveSelectionByGroup = (change: 1 | -1) => {
     const selected = getSelectedVisibleItem();
     let group = selected?.closest(GROUP_SELECTOR) as HTMLElement | null;
-
     while (group) {
       let sibling = change > 0 ? group.nextElementSibling : group.previousElementSibling;
       let nextGroup: HTMLElement | null = null;
@@ -849,33 +646,25 @@ export function createCommand(
         }
         sibling = change > 0 ? sibling.nextElementSibling : sibling.previousElementSibling;
       }
-
       if (!nextGroup) break;
-
-      const nextMeta = getOwnedElements<HTMLElement>(nextGroup, ITEM_SELECTOR, rootEl)
+      const nextMeta = getOwnedCommandElements<HTMLElement>(nextGroup, ITEM_SELECTOR, rootEl)
         .map((el) => itemMetaByElement.get(el) ?? null)
         .find((meta): meta is ItemMeta => meta !== null && !meta.disabled && !meta.el.hidden);
-
       if (nextMeta) {
         setValue(nextMeta.value, { emit: true, ensureVisible: true });
         return;
       }
-
       group = nextGroup;
     }
-
     moveSelectionByItem(change);
   };
-
   const handleKeydown = (event: KeyboardEvent) => {
     if (event.defaultPrevented) return;
     const interactiveTarget = getInteractiveDescendant(event.target);
     if (interactiveTarget && interactiveTarget !== input) return;
-
     const key = event.key.toLowerCase();
     const isComposing = event.isComposing || (event as KeyboardEvent & { keyCode?: number }).keyCode === 229;
     if (isComposing) return;
-
     const next = () => {
       event.preventDefault();
       if (event.metaKey) {
@@ -886,7 +675,6 @@ export function createCommand(
         moveSelectionByItem(1);
       }
     };
-
     const prev = () => {
       event.preventDefault();
       if (event.metaKey) {
@@ -897,7 +685,6 @@ export function createCommand(
         moveSelectionByItem(-1);
       }
     };
-
     switch (key) {
       case "arrowdown":
         next();
@@ -935,7 +722,6 @@ export function createCommand(
         break;
     }
   };
-
   const scheduleMutationRefresh = () => {
     if (mutationQueued || isDestroyed) return;
     mutationQueued = true;
@@ -955,7 +741,6 @@ export function createCommand(
         setValue(nextSelectedMeta.value, { emit: true });
         return;
       }
-
       if (currentValue !== null) {
         const currentMatch = getEnabledVisibleItemsInDomOrder().find((meta) => meta.value === currentValue) ?? null;
         if (currentMatch) {
@@ -963,11 +748,9 @@ export function createCommand(
           return;
         }
       }
-
       setValue(getEnabledVisibleItemsInDomOrder()[0]?.value ?? null, { emit: true });
     });
   };
-
   const observeMutations = () => {
     if (!mutationObserver) return;
     mutationObserver.observe(list, {
@@ -978,32 +761,27 @@ export function createCommand(
       attributeFilter: [...DIRECT_MUTATION_ATTRIBUTES],
     });
   };
-
   if (typeof MutationObserver !== "undefined") {
     mutationObserver = new MutationObserver(() => {
       scheduleMutationRefresh();
     });
     observeMutations();
   }
-
   input.value = currentSearch;
   refreshDisplay();
   if (currentSearch || currentValue === null) {
     selectFirstVisibleItem(false);
   }
-
   cleanups.push(
     on(input, "input", () => {
       setSearchValue(input.value, true, true);
     })
   );
-
   cleanups.push(
     on(rootEl, "keydown", (event) => {
       handleKeydown(event as KeyboardEvent);
     })
   );
-
   cleanups.push(
     on(list, "pointermove", (event) => {
       if (disablePointerSelection) return;
@@ -1015,7 +793,6 @@ export function createCommand(
       setValue(meta.value, { emit: true });
     })
   );
-
   cleanups.push(
     on(list, "click", (event) => {
       const target = event.target as HTMLElement | null;
@@ -1028,12 +805,10 @@ export function createCommand(
       triggerSelection(meta);
     })
   );
-
   cleanups.push(
     on(rootEl, "command:set", (event) => {
       const detail = (event as CustomEvent<{ value?: string | null; search?: string }>).detail;
       if (!detail) return;
-
       if (detail.search !== undefined) {
         setSearchValue(String(detail.search), true, detail.value === undefined);
       }
@@ -1042,7 +817,6 @@ export function createCommand(
       }
     })
   );
-
   const controller: CommandController = {
     get value() {
       return currentValue;
@@ -1068,11 +842,9 @@ export function createCommand(
       clearRootBinding(rootEl, ROOT_BINDING_KEY, controller);
     },
   };
-
   setRootBinding(rootEl, ROOT_BINDING_KEY, controller);
   return controller;
 }
-
 export function create(scope: ParentNode = document): CommandController[] {
   const controllers: CommandController[] = [];
   for (const root of getRoots(scope, "command")) {

--- a/packages/dropdown-menu/src/dropdown-menu-items.ts
+++ b/packages/dropdown-menu/src/dropdown-menu-items.ts
@@ -1,9 +1,10 @@
 import { setAria } from "@data-slot/core";
-import type { DropdownMenuItemRecord, DropdownMenuItemType } from "./dropdown-menu-types";
+import type { CheckboxDiff, DropdownMenuItemRecord, DropdownMenuItemType } from "./dropdown-menu-types";
 
-const ITEM_SELECTOR = '[data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-checkbox-item"]';
+const ITEM_SELECTOR =
+  '[data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-checkbox-item"]';
 
-export interface DropdownItemState {
+interface DropdownItemState {
   value: string | null;
   values: readonly string[];
   highlightedItem: HTMLElement | null;
@@ -20,7 +21,7 @@ const isDisabled = (item: DropdownMenuItemRecord): boolean =>
   item.el.getAttribute("aria-disabled") === "true" ||
   ((item.type === "radio" || item.type === "checkbox") && item.value === null);
 
-/** Owns the DOM-derived menu item model, including selection ARIA and typeahead lookup. */
+/** Owns menu item discovery, lookup, selection reconciliation, and item ARIA. */
 export const createDropdownItemCollection = (root: Element, content: HTMLElement) => {
   let items: DropdownMenuItemRecord[] = [];
   let enabled: DropdownMenuItemRecord[] = [];
@@ -29,24 +30,61 @@ export const createDropdownItemCollection = (root: Element, content: HTMLElement
   const radios = () => items.filter((item) => item.type === "radio");
   const checkboxes = () => items.filter((item) => item.type === "checkbox");
   const recordFor = (el: HTMLElement | null) => items.find((item) => item.el === el) ?? null;
-  const radioFor = (value: string) => radios().find((item) => item.value === value) ?? null;
-  const valueFor = (item: DropdownMenuItemRecord | null): string | null =>
-    !item ? null : item.type === "item" ? item.value || item.el.textContent?.trim() || "" : item.value;
+  const fromTarget = (target: EventTarget | null) =>
+    recordFor(target instanceof Element ? target.closest<HTMLElement>(ITEM_SELECTOR) : null);
+  const radioFor = (value: string, records: readonly DropdownMenuItemRecord[] = items) =>
+    records.find((item) => item.type === "radio" && item.value === value) ?? null;
+  const valueFor = (item: DropdownMenuItemRecord | null): string | null => {
+    if (!item) return null;
+    return item.type === "item" ? item.value || item.el.textContent?.trim() || "" : item.value;
+  };
   const itemForValue = (value: string) => enabled.find((item) => valueFor(item) === value) ?? null;
+
   const checkboxValues = (values: readonly unknown[], mode: "init" | "set"): string[] | null => {
     const available = checkboxes().filter((item) => item.value !== null);
     if (available.length === 0) return null;
-    const requested = new Set(values.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean));
+    // An explicit empty array clears selection; invalid nonempty input is ignored on set.
+    if (values.length === 0) return [];
+    const requested = new Set(
+      values.filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim()).filter(Boolean),
+    );
     if (requested.size === 0) return mode === "init" ? [] : null;
     const canonical = available.flatMap((item) => item.value && requested.has(item.value) ? [item.value] : []);
     return canonical.length > 0 || mode === "init" ? canonical : null;
   };
-  const synchronize = ({ value, values, highlightedItem }: DropdownItemState): void => {
+
+  const checkboxDiff = (
+    previousValues: readonly string[],
+    nextValues: readonly string[],
+    records: readonly DropdownMenuItemRecord[] = items,
+  ): CheckboxDiff => {
+    const previousSet = new Set(previousValues);
+    const nextSet = new Set(nextValues);
+    let changedValue: string | null = null;
+    let checked: boolean | null = null;
+    let item: HTMLElement | null = null;
+    for (const record of records) {
+      if (record.type !== "checkbox" || !record.value) continue;
+      const wasChecked = previousSet.has(record.value);
+      const isChecked = nextSet.has(record.value);
+      if (wasChecked === isChecked) continue;
+      if (changedValue !== null) return { changedValue: null, checked: null, item: null };
+      changedValue = record.value;
+      checked = isChecked;
+      item = record.el;
+    }
+    return { changedValue, checked, item };
+  };
+
+  const synchronizeSelection = (value: string | null, values: readonly string[]): void => {
     for (const item of items) {
-      const disabled = isDisabled(item);
-      item.el.setAttribute("role", item.type === "radio" ? "menuitemradio" : item.type === "checkbox" ? "menuitemcheckbox" : "menuitem");
+      item.el.setAttribute(
+        "role",
+        item.type === "radio" ? "menuitemradio" : item.type === "checkbox" ? "menuitemcheckbox" : "menuitem",
+      );
       item.el.tabIndex = -1;
-      setAria(item.el, "disabled", disabled || null);
+      setAria(item.el, "disabled", isDisabled(item) || null);
       if (item.type === "radio" || item.type === "checkbox") {
         const checked = item.value !== null && (item.type === "radio" ? value === item.value : values.includes(item.value));
         item.el.toggleAttribute("data-checked", checked);
@@ -55,55 +93,48 @@ export const createDropdownItemCollection = (root: Element, content: HTMLElement
         item.el.removeAttribute("data-checked");
         item.el.removeAttribute("aria-checked");
       }
-      item.el.toggleAttribute("data-highlighted", item.el === highlightedItem);
     }
     if (value !== null && radios().length > 0) root.setAttribute("data-value", value);
     else root.removeAttribute("data-value");
   };
+
+  const highlight = (highlightedItem: HTMLElement | null): void => {
+    for (const item of items) item.el.toggleAttribute("data-highlighted", item.el === highlightedItem);
+  };
+
   const refresh = (state: DropdownItemState) => {
     const previousItems = items;
-    items = Array.from(content.querySelectorAll<HTMLElement>(ITEM_SELECTOR)).map((el) => ({ el, type: getType(el), value: el.dataset.value?.trim() || null }));
+    items = Array.from(content.querySelectorAll<HTMLElement>(ITEM_SELECTOR)).map((el) => ({
+      el,
+      type: getType(el),
+      value: el.dataset.value?.trim() || null,
+    }));
     enabled = items.filter((item) => !isDisabled(item));
     index = new Map(enabled.map((item, position) => [item.el, position]));
     const value = state.value !== null && radioFor(state.value) ? state.value : null;
     const values = state.values.length ? checkboxValues(state.values, "init") ?? [] : [];
     const highlightedItem = state.highlightedItem && index.has(state.highlightedItem) ? state.highlightedItem : null;
-    synchronize({ value, values, highlightedItem });
+    synchronizeSelection(value, values);
+    highlight(highlightedItem);
     return { value, values, highlightedItem, previousItems };
   };
-  return { refresh, synchronize, recordFor, radios, checkboxes, radioFor, valueFor, itemForValue, checkboxValues, isDisabled, get items() { return items; }, get enabled() { return enabled; }, enabledIndex: (el: HTMLElement) => index.get(el), isEnabled: (el: HTMLElement) => index.has(el) };
+
+  return {
+    refresh,
+    synchronizeSelection,
+    highlight,
+    recordFor,
+    fromTarget,
+    radios,
+    checkboxes,
+    radioFor,
+    valueFor,
+    itemForValue,
+    checkboxValues,
+    checkboxDiff,
+    isDisabled,
+    get enabled(): readonly DropdownMenuItemRecord[] { return enabled; },
+    enabledIndex: (el: HTMLElement) => index.get(el),
+    isEnabled: (el: HTMLElement) => index.has(el),
+  };
 };
-
-export const arraysEqual = (left: readonly string[], right: readonly string[]): boolean =>
-  left.length === right.length && left.every((value, index) => value === right[index]);
-
-export const dispatchCustomEvent = <T>(el: Element, name: string, detail: T, cancelable = false): boolean =>
-  el.dispatchEvent(new CustomEvent(name, { bubbles: true, cancelable, detail }));
-
-export const parseDefaultValues = (raw: string | undefined): string[] => {
-  try {
-    const values = JSON.parse(raw?.trim() || "[]");
-    return Array.isArray(values) ? values.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean) : [];
-  } catch {
-    return [];
-  }
-};
-
-// Transitional helpers keep the controller's event orchestration independent of
-// DOM discovery while the collection remains the owner of item semantics.
-export const hasOwn = <K extends string>(value: object, key: K): value is Record<K, unknown> =>
-  Object.prototype.hasOwnProperty.call(value, key);
-
-export const setPresence = (el: Element, name: string, present: boolean): void => {
-  el.toggleAttribute(name, present);
-};
-
-export const getItemRole = (type: DropdownMenuItemType): string =>
-  type === "radio" ? "menuitemradio" : type === "checkbox" ? "menuitemcheckbox" : "menuitem";
-
-export const getItemType = getType;
-
-export const readSelectableValue = (el: HTMLElement): string | null => el.dataset.value?.trim() || null;
-
-export const readActionValue = (item: DropdownMenuItemRecord): string =>
-  item.type === "item" ? item.value || item.el.textContent?.trim() || "" : item.value || "";

--- a/packages/dropdown-menu/src/dropdown-menu-items.ts
+++ b/packages/dropdown-menu/src/dropdown-menu-items.ts
@@ -1,12 +1,109 @@
+import { setAria } from "@data-slot/core";
 import type { DropdownMenuItemRecord, DropdownMenuItemType } from "./dropdown-menu-types";
 
-/** Value and ARIA rules shared by the menu's item collection. */
-export const hasOwn = <K extends string>(value: object, key: K): value is Record<K, unknown> => Object.prototype.hasOwnProperty.call(value, key);
-export const setPresence = (el: Element, name: string, present: boolean): void => { if (present) el.setAttribute(name, ""); else el.removeAttribute(name); };
-export const arraysEqual = (left: readonly string[], right: readonly string[]): boolean => left.length === right.length && left.every((value, index) => value === right[index]);
-export const dispatchCustomEvent = <T>(el: Element, name: string, detail: T, cancelable = false): boolean => el.dispatchEvent(new CustomEvent(name, { bubbles: true, cancelable, detail }));
-export const getItemRole = (type: DropdownMenuItemType): string => type === "radio" ? "menuitemradio" : type === "checkbox" ? "menuitemcheckbox" : "menuitem";
-export const getItemType = (el: HTMLElement): DropdownMenuItemType => el.getAttribute("data-slot") === "dropdown-menu-radio-item" ? "radio" : el.getAttribute("data-slot") === "dropdown-menu-checkbox-item" ? "checkbox" : "item";
-export const readSelectableValue = (el: HTMLElement): string | null => { const value = el.dataset.value?.trim(); return value || null; };
-export const readActionValue = (item: DropdownMenuItemRecord): string => item.type === "item" ? item.value || item.el.textContent?.trim() || "" : item.value || "";
-export const parseDefaultValues = (raw: string | undefined): string[] => { try { const values = JSON.parse(raw?.trim() || "[]"); return Array.isArray(values) ? values.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean) : []; } catch { return []; } };
+const ITEM_SELECTOR = '[data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-checkbox-item"]';
+
+export interface DropdownItemState {
+  value: string | null;
+  values: readonly string[];
+  highlightedItem: HTMLElement | null;
+}
+
+const getType = (el: HTMLElement): DropdownMenuItemType => {
+  if (el.getAttribute("data-slot") === "dropdown-menu-radio-item") return "radio";
+  if (el.getAttribute("data-slot") === "dropdown-menu-checkbox-item") return "checkbox";
+  return "item";
+};
+
+const isDisabled = (item: DropdownMenuItemRecord): boolean =>
+  item.el.hasAttribute("disabled") || item.el.hasAttribute("data-disabled") ||
+  item.el.getAttribute("aria-disabled") === "true" ||
+  ((item.type === "radio" || item.type === "checkbox") && item.value === null);
+
+/** Owns the DOM-derived menu item model, including selection ARIA and typeahead lookup. */
+export const createDropdownItemCollection = (root: Element, content: HTMLElement) => {
+  let items: DropdownMenuItemRecord[] = [];
+  let enabled: DropdownMenuItemRecord[] = [];
+  let index = new Map<HTMLElement, number>();
+
+  const radios = () => items.filter((item) => item.type === "radio");
+  const checkboxes = () => items.filter((item) => item.type === "checkbox");
+  const recordFor = (el: HTMLElement | null) => items.find((item) => item.el === el) ?? null;
+  const radioFor = (value: string) => radios().find((item) => item.value === value) ?? null;
+  const valueFor = (item: DropdownMenuItemRecord | null): string | null =>
+    !item ? null : item.type === "item" ? item.value || item.el.textContent?.trim() || "" : item.value;
+  const itemForValue = (value: string) => enabled.find((item) => valueFor(item) === value) ?? null;
+  const checkboxValues = (values: readonly unknown[], mode: "init" | "set"): string[] | null => {
+    const available = checkboxes().filter((item) => item.value !== null);
+    if (available.length === 0) return null;
+    const requested = new Set(values.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean));
+    if (requested.size === 0) return mode === "init" ? [] : null;
+    const canonical = available.flatMap((item) => item.value && requested.has(item.value) ? [item.value] : []);
+    return canonical.length > 0 || mode === "init" ? canonical : null;
+  };
+  const synchronize = ({ value, values, highlightedItem }: DropdownItemState): void => {
+    for (const item of items) {
+      const disabled = isDisabled(item);
+      item.el.setAttribute("role", item.type === "radio" ? "menuitemradio" : item.type === "checkbox" ? "menuitemcheckbox" : "menuitem");
+      item.el.tabIndex = -1;
+      setAria(item.el, "disabled", disabled || null);
+      if (item.type === "radio" || item.type === "checkbox") {
+        const checked = item.value !== null && (item.type === "radio" ? value === item.value : values.includes(item.value));
+        item.el.toggleAttribute("data-checked", checked);
+        setAria(item.el, "checked", item.value === null ? null : checked);
+      } else {
+        item.el.removeAttribute("data-checked");
+        item.el.removeAttribute("aria-checked");
+      }
+      item.el.toggleAttribute("data-highlighted", item.el === highlightedItem);
+    }
+    if (value !== null && radios().length > 0) root.setAttribute("data-value", value);
+    else root.removeAttribute("data-value");
+  };
+  const refresh = (state: DropdownItemState) => {
+    const previousItems = items;
+    items = Array.from(content.querySelectorAll<HTMLElement>(ITEM_SELECTOR)).map((el) => ({ el, type: getType(el), value: el.dataset.value?.trim() || null }));
+    enabled = items.filter((item) => !isDisabled(item));
+    index = new Map(enabled.map((item, position) => [item.el, position]));
+    const value = state.value !== null && radioFor(state.value) ? state.value : null;
+    const values = state.values.length ? checkboxValues(state.values, "init") ?? [] : [];
+    const highlightedItem = state.highlightedItem && index.has(state.highlightedItem) ? state.highlightedItem : null;
+    synchronize({ value, values, highlightedItem });
+    return { value, values, highlightedItem, previousItems };
+  };
+  return { refresh, synchronize, recordFor, radios, checkboxes, radioFor, valueFor, itemForValue, checkboxValues, isDisabled, get items() { return items; }, get enabled() { return enabled; }, enabledIndex: (el: HTMLElement) => index.get(el), isEnabled: (el: HTMLElement) => index.has(el) };
+};
+
+export const arraysEqual = (left: readonly string[], right: readonly string[]): boolean =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
+export const dispatchCustomEvent = <T>(el: Element, name: string, detail: T, cancelable = false): boolean =>
+  el.dispatchEvent(new CustomEvent(name, { bubbles: true, cancelable, detail }));
+
+export const parseDefaultValues = (raw: string | undefined): string[] => {
+  try {
+    const values = JSON.parse(raw?.trim() || "[]");
+    return Array.isArray(values) ? values.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+};
+
+// Transitional helpers keep the controller's event orchestration independent of
+// DOM discovery while the collection remains the owner of item semantics.
+export const hasOwn = <K extends string>(value: object, key: K): value is Record<K, unknown> =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+export const setPresence = (el: Element, name: string, present: boolean): void => {
+  el.toggleAttribute(name, present);
+};
+
+export const getItemRole = (type: DropdownMenuItemType): string =>
+  type === "radio" ? "menuitemradio" : type === "checkbox" ? "menuitemcheckbox" : "menuitem";
+
+export const getItemType = getType;
+
+export const readSelectableValue = (el: HTMLElement): string | null => el.dataset.value?.trim() || null;
+
+export const readActionValue = (item: DropdownMenuItemRecord): string =>
+  item.type === "item" ? item.value || item.el.textContent?.trim() || "" : item.value || "";

--- a/packages/dropdown-menu/src/dropdown-menu-items.ts
+++ b/packages/dropdown-menu/src/dropdown-menu-items.ts
@@ -1,0 +1,12 @@
+import type { DropdownMenuItemRecord, DropdownMenuItemType } from "./dropdown-menu-types";
+
+/** Value and ARIA rules shared by the menu's item collection. */
+export const hasOwn = <K extends string>(value: object, key: K): value is Record<K, unknown> => Object.prototype.hasOwnProperty.call(value, key);
+export const setPresence = (el: Element, name: string, present: boolean): void => { if (present) el.setAttribute(name, ""); else el.removeAttribute(name); };
+export const arraysEqual = (left: readonly string[], right: readonly string[]): boolean => left.length === right.length && left.every((value, index) => value === right[index]);
+export const dispatchCustomEvent = <T>(el: Element, name: string, detail: T, cancelable = false): boolean => el.dispatchEvent(new CustomEvent(name, { bubbles: true, cancelable, detail }));
+export const getItemRole = (type: DropdownMenuItemType): string => type === "radio" ? "menuitemradio" : type === "checkbox" ? "menuitemcheckbox" : "menuitem";
+export const getItemType = (el: HTMLElement): DropdownMenuItemType => el.getAttribute("data-slot") === "dropdown-menu-radio-item" ? "radio" : el.getAttribute("data-slot") === "dropdown-menu-checkbox-item" ? "checkbox" : "item";
+export const readSelectableValue = (el: HTMLElement): string | null => { const value = el.dataset.value?.trim(); return value || null; };
+export const readActionValue = (item: DropdownMenuItemRecord): string => item.type === "item" ? item.value || item.el.textContent?.trim() || "" : item.value || "";
+export const parseDefaultValues = (raw: string | undefined): string[] => { try { const values = JSON.parse(raw?.trim() || "[]"); return Array.isArray(values) ? values.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean) : []; } catch { return []; } };

--- a/packages/dropdown-menu/src/dropdown-menu-options.ts
+++ b/packages/dropdown-menu/src/dropdown-menu-options.ts
@@ -1,9 +1,22 @@
 import { getDataBool, getDataEnum, getDataNumber, getDataString } from "@data-slot/core";
 import type { Align, DropdownMenuOptions, Side } from "./dropdown-menu-types";
-import { hasOwn, parseDefaultValues } from "./dropdown-menu-items";
 
 const sides = ["top", "right", "bottom", "left"] as const;
 const aligns = ["start", "center", "end"] as const;
+
+const hasOwn = <K extends string>(value: object, key: K): value is Record<K, unknown> =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const parseDefaultValues = (raw: string | undefined): string[] => {
+  try {
+    const values = JSON.parse(raw?.trim() || "[]");
+    return Array.isArray(values)
+      ? values.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean)
+      : [];
+  } catch {
+    return [];
+  }
+};
 
 /** Resolves authored data attributes once, preserving option precedence. */
 export const resolveDropdownMenuOptions = (root: Element, content: HTMLElement, positioner: HTMLElement | null, options: DropdownMenuOptions) => {

--- a/packages/dropdown-menu/src/dropdown-menu-options.ts
+++ b/packages/dropdown-menu/src/dropdown-menu-options.ts
@@ -1,0 +1,35 @@
+import { getDataBool, getDataEnum, getDataNumber, getDataString } from "@data-slot/core";
+import type { Align, DropdownMenuOptions, Side } from "./dropdown-menu-types";
+import { hasOwn, parseDefaultValues } from "./dropdown-menu-items";
+
+const sides = ["top", "right", "bottom", "left"] as const;
+const aligns = ["start", "center", "end"] as const;
+
+/** Resolves authored data attributes once, preserving option precedence. */
+export const resolveDropdownMenuOptions = (root: Element, content: HTMLElement, positioner: HTMLElement | null, options: DropdownMenuOptions) => {
+  const enumValue = <T extends string>(key: string, allowed: readonly T[]) => getDataEnum(content, key, allowed) ?? (positioner ? getDataEnum(positioner, key, allowed) : undefined) ?? getDataEnum(root, key, allowed);
+  const numberValue = (key: string) => getDataNumber(content, key) ?? (positioner ? getDataNumber(positioner, key) : undefined) ?? getDataNumber(root, key);
+  const boolValue = (key: string) => getDataBool(content, key) ?? (positioner ? getDataBool(positioner, key) : undefined) ?? getDataBool(root, key);
+  const hasValue = hasOwn(options, "defaultValue");
+  const hasValues = hasOwn(options, "defaultValues");
+  const rootHasValue = root.hasAttribute("data-default-value");
+  const rootHasValues = root.hasAttribute("data-default-values");
+  return {
+    defaultOpen: options.defaultOpen ?? getDataBool(root, "defaultOpen") ?? false,
+    closeOnClickOutside: options.closeOnClickOutside ?? getDataBool(root, "closeOnClickOutside") ?? true,
+    closeOnEscape: options.closeOnEscape ?? getDataBool(root, "closeOnEscape") ?? true,
+    closeOnSelect: options.closeOnSelect ?? getDataBool(root, "closeOnSelect") ?? true,
+    preferredSide: options.side ?? enumValue<Side>("side", sides) ?? "bottom",
+    preferredAlign: options.align ?? enumValue<Align>("align", aligns) ?? "start",
+    sideOffset: options.sideOffset ?? numberValue("sideOffset") ?? 4,
+    alignOffset: options.alignOffset ?? numberValue("alignOffset") ?? 0,
+    avoidCollisions: options.avoidCollisions ?? boolValue("avoidCollisions") ?? true,
+    collisionPadding: options.collisionPadding ?? numberValue("collisionPadding") ?? 8,
+    lockScroll: options.lockScroll ?? getDataBool(root, "lockScroll") ?? true,
+    highlightItemOnHover: options.highlightItemOnHover ?? getDataBool(root, "highlightItemOnHover") ?? true,
+    optionsHasDefaultValue: hasValue, optionsHasDefaultValues: hasValues,
+    rootHasDefaultValue: rootHasValue, rootHasDefaultValues: rootHasValues,
+    requestedDefaultValue: hasValue ? options.defaultValue ?? null : rootHasValue ? getDataString(root, "defaultValue") ?? null : null,
+    requestedDefaultValues: hasValues ? options.defaultValues ?? [] : rootHasValues ? parseDefaultValues(getDataString(root, "defaultValues")) : [],
+  };
+};

--- a/packages/dropdown-menu/src/dropdown-menu-types.ts
+++ b/packages/dropdown-menu/src/dropdown-menu-types.ts
@@ -1,28 +1,183 @@
+/** Side of the trigger to place the content */
 export type Side = "top" | "right" | "bottom" | "left";
+
+/** Alignment of the content relative to the trigger */
 export type Align = "start" | "center" | "end";
+
 export type DropdownMenuItemType = "item" | "radio" | "checkbox";
 export type DropdownMenuUserSource = "pointer" | "keyboard";
 export type DropdownMenuSetSource = "programmatic" | "restore";
 export type DropdownMenuSelectionSource = DropdownMenuUserSource | DropdownMenuSetSource;
 export type DropdownMenuOpenChangeSource = DropdownMenuSelectionSource | "init";
-export type DropdownMenuOpenChangeReason = "trigger" | "select" | "outside" | "escape" | "tab" | "programmatic" | "init";
-export interface DropdownMenuOpenChangeDetail { open: boolean; previousOpen: boolean; source: DropdownMenuOpenChangeSource; reason: DropdownMenuOpenChangeReason; }
-export interface DropdownMenuHighlightChangeDetail { value: string | null; previousValue: string | null; item: HTMLElement | null; previousItem: HTMLElement | null; source: DropdownMenuSelectionSource; }
-export interface DropdownMenuSelectDetail { value: string; item: HTMLElement; itemType: DropdownMenuItemType; source: DropdownMenuUserSource; checked?: boolean; }
-export interface DropdownMenuValueChangeDetail { value: string | null; previousValue: string | null; item: HTMLElement | null; previousItem: HTMLElement | null; source: DropdownMenuSelectionSource; }
-export interface DropdownMenuValuesChangeDetail { values: string[]; previousValues: string[]; changedValue: string | null; checked: boolean | null; item: HTMLElement | null; source: DropdownMenuSelectionSource; }
-export interface DropdownMenuSetDetail { open?: boolean; value?: string | null; values?: string[]; highlightedValue?: string | null; source?: DropdownMenuSetSource; }
-export interface DropdownMenuOptions {
-  defaultOpen?: boolean; defaultValue?: string | null; defaultValues?: string[];
-  onOpenChange?: (open: boolean) => void; onSelect?: (value: string) => void;
-  onValueChange?: (value: string | null) => void; onValuesChange?: (values: string[]) => void;
-  closeOnClickOutside?: boolean; closeOnEscape?: boolean; closeOnSelect?: boolean;
-  side?: Side; align?: Align; sideOffset?: number; alignOffset?: number;
-  avoidCollisions?: boolean; collisionPadding?: number; lockScroll?: boolean; highlightItemOnHover?: boolean;
+export type DropdownMenuOpenChangeReason =
+  | "trigger"
+  | "select"
+  | "outside"
+  | "escape"
+  | "tab"
+  | "programmatic"
+  | "init";
+
+export interface DropdownMenuOpenChangeDetail {
+  open: boolean;
+  previousOpen: boolean;
+  source: DropdownMenuOpenChangeSource;
+  reason: DropdownMenuOpenChangeReason;
 }
-export interface DropdownMenuController { open(): void; close(): void; toggle(): void; set(detail: DropdownMenuSetDetail): void; readonly isOpen: boolean; readonly value: string | null; readonly values: string[]; readonly highlightedValue: string | null; destroy(): void; }
-export interface DropdownMenuItemRecord { el: HTMLElement; type: DropdownMenuItemType; value: string | null; }
-export interface OpenTransitionOptions { source: DropdownMenuOpenChangeSource; reason: DropdownMenuOpenChangeReason; }
-export interface HighlightUpdateOptions { source: DropdownMenuSelectionSource; focus?: boolean; focusContentOnClear?: boolean; }
-export interface CheckboxDiff { changedValue: string | null; checked: boolean | null; item: HTMLElement | null; }
-export interface CacheItemsOptions { source?: DropdownMenuSelectionSource; emitSelectionInvalidation?: boolean; }
+
+export interface DropdownMenuHighlightChangeDetail {
+  value: string | null;
+  previousValue: string | null;
+  item: HTMLElement | null;
+  previousItem: HTMLElement | null;
+  source: DropdownMenuSelectionSource;
+}
+
+export interface DropdownMenuSelectDetail {
+  value: string;
+  item: HTMLElement;
+  itemType: DropdownMenuItemType;
+  source: DropdownMenuUserSource;
+  checked?: boolean;
+}
+
+export interface DropdownMenuValueChangeDetail {
+  value: string | null;
+  previousValue: string | null;
+  item: HTMLElement | null;
+  previousItem: HTMLElement | null;
+  source: DropdownMenuSelectionSource;
+}
+
+export interface DropdownMenuValuesChangeDetail {
+  values: string[];
+  previousValues: string[];
+  changedValue: string | null;
+  checked: boolean | null;
+  item: HTMLElement | null;
+  source: DropdownMenuSelectionSource;
+}
+
+export interface DropdownMenuSetDetail {
+  open?: boolean;
+  value?: string | null;
+  values?: string[];
+  highlightedValue?: string | null;
+  source?: DropdownMenuSetSource;
+}
+
+export interface DropdownMenuOptions {
+  /** Initial open state */
+  defaultOpen?: boolean;
+  /** Initial radio selection state */
+  defaultValue?: string | null;
+  /** Initial checkbox selection state */
+  defaultValues?: string[];
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void;
+  /** Callback when a user activation is accepted */
+  onSelect?: (value: string) => void;
+  /** Callback when the committed radio value changes */
+  onValueChange?: (value: string | null) => void;
+  /** Callback when the committed checkbox values change */
+  onValuesChange?: (values: string[]) => void;
+  /** Close when clicking outside */
+  closeOnClickOutside?: boolean;
+  /** Close when pressing Escape */
+  closeOnEscape?: boolean;
+  /** Close when an item is selected */
+  closeOnSelect?: boolean;
+
+  // Positioning props (Radix-compatible)
+  /**
+   * The preferred side of the trigger to render against.
+   * Will be reversed when collisions occur and `avoidCollisions` is enabled.
+   * @default "bottom"
+   */
+  side?: Side;
+  /**
+   * The preferred alignment against the trigger.
+   * May change when collisions occur.
+   * @default "start"
+   */
+  align?: Align;
+  /**
+   * The distance in pixels from the trigger.
+   * @default 4
+   */
+  sideOffset?: number;
+  /**
+   * An offset in pixels from the "start" or "end" alignment options.
+   * @default 0
+   */
+  alignOffset?: number;
+  /**
+   * When true, overrides side/align preferences to prevent collisions with viewport edges.
+   * @default true
+   */
+  avoidCollisions?: boolean;
+  /**
+   * The padding between the content and the viewport edges when avoiding collisions.
+   * @default 8
+   */
+  collisionPadding?: number;
+  /**
+   * Lock body scroll when open.
+   * @default true
+   */
+  lockScroll?: boolean;
+  /**
+   * Whether moving the pointer over items should highlight and focus them.
+   * @default true
+   */
+  highlightItemOnHover?: boolean;
+}
+
+export interface DropdownMenuController {
+  /** Open the dropdown menu */
+  open(): void;
+  /** Close the dropdown menu */
+  close(): void;
+  /** Toggle the dropdown menu */
+  toggle(): void;
+  /** Set one or more dropdown menu state fields programmatically */
+  set(detail: DropdownMenuSetDetail): void;
+  /** Current open state */
+  readonly isOpen: boolean;
+  /** Current committed radio value */
+  readonly value: string | null;
+  /** Current committed checkbox values */
+  readonly values: string[];
+  /** Current highlighted value */
+  readonly highlightedValue: string | null;
+  /** Cleanup all event listeners */
+  destroy(): void;
+}
+
+export interface DropdownMenuItemRecord {
+  el: HTMLElement;
+  type: DropdownMenuItemType;
+  value: string | null;
+}
+
+export interface OpenTransitionOptions {
+  source: DropdownMenuOpenChangeSource;
+  reason: DropdownMenuOpenChangeReason;
+}
+
+export interface HighlightUpdateOptions {
+  source: DropdownMenuSelectionSource;
+  focus?: boolean;
+  focusContentOnClear?: boolean;
+}
+
+export interface CheckboxDiff {
+  changedValue: string | null;
+  checked: boolean | null;
+  item: HTMLElement | null;
+}
+
+export interface CacheItemsOptions {
+  source?: DropdownMenuSelectionSource;
+  emitSelectionInvalidation?: boolean;
+}

--- a/packages/dropdown-menu/src/dropdown-menu-types.ts
+++ b/packages/dropdown-menu/src/dropdown-menu-types.ts
@@ -1,0 +1,28 @@
+export type Side = "top" | "right" | "bottom" | "left";
+export type Align = "start" | "center" | "end";
+export type DropdownMenuItemType = "item" | "radio" | "checkbox";
+export type DropdownMenuUserSource = "pointer" | "keyboard";
+export type DropdownMenuSetSource = "programmatic" | "restore";
+export type DropdownMenuSelectionSource = DropdownMenuUserSource | DropdownMenuSetSource;
+export type DropdownMenuOpenChangeSource = DropdownMenuSelectionSource | "init";
+export type DropdownMenuOpenChangeReason = "trigger" | "select" | "outside" | "escape" | "tab" | "programmatic" | "init";
+export interface DropdownMenuOpenChangeDetail { open: boolean; previousOpen: boolean; source: DropdownMenuOpenChangeSource; reason: DropdownMenuOpenChangeReason; }
+export interface DropdownMenuHighlightChangeDetail { value: string | null; previousValue: string | null; item: HTMLElement | null; previousItem: HTMLElement | null; source: DropdownMenuSelectionSource; }
+export interface DropdownMenuSelectDetail { value: string; item: HTMLElement; itemType: DropdownMenuItemType; source: DropdownMenuUserSource; checked?: boolean; }
+export interface DropdownMenuValueChangeDetail { value: string | null; previousValue: string | null; item: HTMLElement | null; previousItem: HTMLElement | null; source: DropdownMenuSelectionSource; }
+export interface DropdownMenuValuesChangeDetail { values: string[]; previousValues: string[]; changedValue: string | null; checked: boolean | null; item: HTMLElement | null; source: DropdownMenuSelectionSource; }
+export interface DropdownMenuSetDetail { open?: boolean; value?: string | null; values?: string[]; highlightedValue?: string | null; source?: DropdownMenuSetSource; }
+export interface DropdownMenuOptions {
+  defaultOpen?: boolean; defaultValue?: string | null; defaultValues?: string[];
+  onOpenChange?: (open: boolean) => void; onSelect?: (value: string) => void;
+  onValueChange?: (value: string | null) => void; onValuesChange?: (values: string[]) => void;
+  closeOnClickOutside?: boolean; closeOnEscape?: boolean; closeOnSelect?: boolean;
+  side?: Side; align?: Align; sideOffset?: number; alignOffset?: number;
+  avoidCollisions?: boolean; collisionPadding?: number; lockScroll?: boolean; highlightItemOnHover?: boolean;
+}
+export interface DropdownMenuController { open(): void; close(): void; toggle(): void; set(detail: DropdownMenuSetDetail): void; readonly isOpen: boolean; readonly value: string | null; readonly values: string[]; readonly highlightedValue: string | null; destroy(): void; }
+export interface DropdownMenuItemRecord { el: HTMLElement; type: DropdownMenuItemType; value: string | null; }
+export interface OpenTransitionOptions { source: DropdownMenuOpenChangeSource; reason: DropdownMenuOpenChangeReason; }
+export interface HighlightUpdateOptions { source: DropdownMenuSelectionSource; focus?: boolean; focusContentOnClear?: boolean; }
+export interface CheckboxDiff { changedValue: string | null; checked: boolean | null; item: HTMLElement | null; }
+export interface CacheItemsOptions { source?: DropdownMenuSelectionSource; emitSelectionInvalidation?: boolean; }

--- a/packages/dropdown-menu/src/index.test.ts
+++ b/packages/dropdown-menu/src/index.test.ts
@@ -595,6 +595,47 @@ describe("DropdownMenu", () => {
       controller.destroy();
     });
 
+    for (const action of ["click", "set"]) {
+      it(`clears the last checkbox through ${action}`, () => {
+        const { root, controller } = setup(
+          { defaultValues: ["email"], closeOnSelect: false },
+          `
+          <div data-slot="dropdown-menu" id="root">
+            <button data-slot="dropdown-menu-trigger">Options</button>
+            <div data-slot="dropdown-menu-content">
+              <button data-slot="dropdown-menu-checkbox-item" data-value="email">Email</button>
+            </div>
+          </div>
+          `,
+        );
+        const item = root.querySelector<HTMLElement>('[data-slot="dropdown-menu-checkbox-item"]')!;
+        const changes: unknown[] = [];
+        root.addEventListener("dropdown-menu:values-change", (event) => {
+          changes.push((event as CustomEvent).detail);
+        });
+        try {
+          controller.open();
+          if (action === "click") item.click();
+          else controller.set({ values: [] });
+
+          expect(controller.values).toEqual([]);
+          expect(item.getAttribute("aria-checked")).toBe("false");
+          expect(item.hasAttribute("data-checked")).toBe(false);
+          expect(controller.isOpen).toBe(true);
+          expect(changes).toEqual([{
+            values: [],
+            previousValues: ["email"],
+            changedValue: "email",
+            checked: false,
+            item,
+            source: action === "click" ? "pointer" : "programmatic",
+          }]);
+        } finally {
+          controller.destroy();
+        }
+      });
+    }
+
     it("supports canceling dropdown-menu:select before commit and close", () => {
       const { root, trigger, controller } = setup(
         {},

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -27,7 +27,7 @@ import {
   containsWithPortals,
 } from "@data-slot/core";
 import { resolveDropdownMenuOptions } from "./dropdown-menu-options";
-import { arraysEqual, dispatchCustomEvent, getItemRole, getItemType, hasOwn, parseDefaultValues, readActionValue, readSelectableValue, setPresence } from "./dropdown-menu-items";
+import { arraysEqual, createDropdownItemCollection, dispatchCustomEvent, getItemRole, getItemType, hasOwn, parseDefaultValues, readActionValue, readSelectableValue, setPresence } from "./dropdown-menu-items";
 export type { Align, DropdownMenuController, DropdownMenuHighlightChangeDetail, DropdownMenuItemType, DropdownMenuOpenChangeDetail, DropdownMenuOpenChangeReason, DropdownMenuOpenChangeSource, DropdownMenuOptions, DropdownMenuSelectDetail, DropdownMenuSelectionSource, DropdownMenuSetDetail, DropdownMenuSetSource, DropdownMenuUserSource, DropdownMenuValueChangeDetail, DropdownMenuValuesChangeDetail, Side } from "./dropdown-menu-types";
 import type { CacheItemsOptions, CheckboxDiff, DropdownMenuController, DropdownMenuHighlightChangeDetail, DropdownMenuItemRecord, DropdownMenuItemType, DropdownMenuOpenChangeDetail, DropdownMenuOpenChangeSource, DropdownMenuOptions, DropdownMenuSelectDetail, DropdownMenuSelectionSource, DropdownMenuSetDetail, DropdownMenuValueChangeDetail, DropdownMenuValuesChangeDetail, HighlightUpdateOptions, OpenTransitionOptions } from "./dropdown-menu-types";
 const SIDES = ["top", "right", "bottom", "left"] as const;
@@ -112,6 +112,7 @@ export function createDropdownMenu(
     container: authoredPositioner ?? undefined,
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
+  const itemCollection = createDropdownItemCollection(root, content);
   let items: DropdownMenuItemRecord[] = [];
   let enabledItems: DropdownMenuItemRecord[] = [];
   let itemToEnabledIndex = new Map<HTMLElement, number>();
@@ -238,11 +239,12 @@ export function createDropdownMenu(
     const previousItems = items;
     const previousValue = currentValue;
     const previousValues = [...currentValues];
-    items = Array.from(content.querySelectorAll<HTMLElement>(ITEM_SELECTOR)).map((el) => ({
-      el,
-      type: getItemType(el),
-      value: readSelectableValue(el),
-    }));
+    itemCollection.refresh({
+      value: previousValue,
+      values: previousValues,
+      highlightedItem,
+    });
+    items = [...itemCollection.items];
     const nextValue =
       previousValue !== null && findRadioItemByValue(previousValue) ? previousValue : null;
     const nextValues =

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -2,9 +2,6 @@ import {
   getPart,
   getRoots,
   getDataBool,
-  getDataNumber,
-  getDataString,
-  getDataEnum,
   hasRootBinding,
   reuseRootBinding,
   setRootBinding,
@@ -27,14 +24,52 @@ import {
   containsWithPortals,
 } from "@data-slot/core";
 import { resolveDropdownMenuOptions } from "./dropdown-menu-options";
-import { arraysEqual, createDropdownItemCollection, dispatchCustomEvent, getItemRole, getItemType, hasOwn, parseDefaultValues, readActionValue, readSelectableValue, setPresence } from "./dropdown-menu-items";
-export type { Align, DropdownMenuController, DropdownMenuHighlightChangeDetail, DropdownMenuItemType, DropdownMenuOpenChangeDetail, DropdownMenuOpenChangeReason, DropdownMenuOpenChangeSource, DropdownMenuOptions, DropdownMenuSelectDetail, DropdownMenuSelectionSource, DropdownMenuSetDetail, DropdownMenuSetSource, DropdownMenuUserSource, DropdownMenuValueChangeDetail, DropdownMenuValuesChangeDetail, Side } from "./dropdown-menu-types";
-import type { CacheItemsOptions, CheckboxDiff, DropdownMenuController, DropdownMenuHighlightChangeDetail, DropdownMenuItemRecord, DropdownMenuItemType, DropdownMenuOpenChangeDetail, DropdownMenuOpenChangeSource, DropdownMenuOptions, DropdownMenuSelectDetail, DropdownMenuSelectionSource, DropdownMenuSetDetail, DropdownMenuValueChangeDetail, DropdownMenuValuesChangeDetail, HighlightUpdateOptions, OpenTransitionOptions } from "./dropdown-menu-types";
-const SIDES = ["top", "right", "bottom", "left"] as const;
-const ALIGNS = ["start", "center", "end"] as const;
+import { createDropdownItemCollection } from "./dropdown-menu-items";
+import type {
+  CacheItemsOptions,
+  DropdownMenuController,
+  DropdownMenuHighlightChangeDetail,
+  DropdownMenuItemRecord,
+  DropdownMenuOpenChangeDetail,
+  DropdownMenuOpenChangeSource,
+  DropdownMenuOptions,
+  DropdownMenuSelectDetail,
+  DropdownMenuSelectionSource,
+  DropdownMenuSetDetail,
+  DropdownMenuUserSource,
+  DropdownMenuValueChangeDetail,
+  DropdownMenuValuesChangeDetail,
+  HighlightUpdateOptions,
+  OpenTransitionOptions,
+} from "./dropdown-menu-types";
+
+export type {
+  Align,
+  DropdownMenuController,
+  DropdownMenuHighlightChangeDetail,
+  DropdownMenuItemType,
+  DropdownMenuOpenChangeDetail,
+  DropdownMenuOpenChangeReason,
+  DropdownMenuOpenChangeSource,
+  DropdownMenuOptions,
+  DropdownMenuSelectDetail,
+  DropdownMenuSelectionSource,
+  DropdownMenuSetDetail,
+  DropdownMenuSetSource,
+  DropdownMenuUserSource,
+  DropdownMenuValueChangeDetail,
+  DropdownMenuValuesChangeDetail,
+  Side,
+} from "./dropdown-menu-types";
+
 const ROOT_BINDING_KEY = "@data-slot/dropdown-menu";
 const DUPLICATE_BINDING_WARNING = "[@data-slot/dropdown-menu] createDropdownMenu() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
-const ITEM_SELECTOR = '[data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-checkbox-item"]';
+const arraysEqual = (left: readonly string[], right: readonly string[]): boolean =>
+  left.length === right.length && left.every((value, index) => value === right[index]);
+
+const dispatchCustomEvent = <T>(el: Element, name: string, detail: T, cancelable = false): boolean =>
+  el.dispatchEvent(new CustomEvent(name, { bubbles: true, cancelable, detail }));
+
 /**
  * Create a dropdown menu controller for a root element.
  *
@@ -113,166 +148,40 @@ export function createDropdownMenu(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const itemCollection = createDropdownItemCollection(root, content);
-  let items: DropdownMenuItemRecord[] = [];
-  let enabledItems: DropdownMenuItemRecord[] = [];
-  let itemToEnabledIndex = new Map<HTMLElement, number>();
-  const isDisabledEl = (el: HTMLElement): boolean =>
-    el.hasAttribute("disabled") || el.hasAttribute("data-disabled") || el.getAttribute("aria-disabled") === "true";
   const isHoverPointer = (e: PointerEvent) => e.pointerType !== "touch";
-  const closestItem = (target: EventTarget | null): HTMLElement | null =>
-    target instanceof Element ? (target.closest(ITEM_SELECTOR) as HTMLElement | null) : null;
-  const getItemRecord = (el: HTMLElement | null): DropdownMenuItemRecord | null =>
-    el ? items.find((item) => item.el === el) ?? null : null;
-  const getRadioItems = (): DropdownMenuItemRecord[] => items.filter((item) => item.type === "radio");
-  const getCheckboxItems = (): DropdownMenuItemRecord[] => items.filter((item) => item.type === "checkbox");
-  const findRadioItemByValueIn = (
-    records: readonly DropdownMenuItemRecord[],
-    value: string,
-  ): DropdownMenuItemRecord | null =>
-    records.find((item) => item.type === "radio" && item.value === value) ?? null;
-  const getResolvedValue = (item: DropdownMenuItemRecord | null): string | null => {
-    if (!item) return null;
-    if (item.type === "item") {
-      return readActionValue(item);
-    }
-    return item.value;
-  };
-  const isInvalidSelectableItem = (item: DropdownMenuItemRecord): boolean =>
-    (item.type === "radio" || item.type === "checkbox") && item.value === null;
-  const isItemDisabled = (item: DropdownMenuItemRecord): boolean =>
-    isDisabledEl(item.el) || isInvalidSelectableItem(item);
-  const findRadioItemByValue = (value: string): DropdownMenuItemRecord | null =>
-    getRadioItems().find((item) => item.value === value) ?? null;
-  const findItemByResolvedValue = (value: string): DropdownMenuItemRecord | null =>
-    enabledItems.find((item) => getResolvedValue(item) === value) ?? null;
-  const getCheckboxDiff = (
-    previousValues: readonly string[],
-    nextValues: readonly string[],
-    checkboxItems: readonly DropdownMenuItemRecord[] = getCheckboxItems(),
-  ): CheckboxDiff => {
-    const previousSet = new Set(previousValues);
-    const nextSet = new Set(nextValues);
-    let changedValue: string | null = null;
-    let checked: boolean | null = null;
-    let item: HTMLElement | null = null;
-    for (const checkboxItem of checkboxItems) {
-      if (checkboxItem.type !== "checkbox") continue;
-      const value = checkboxItem.value;
-      if (!value) continue;
-      const wasChecked = previousSet.has(value);
-      const isChecked = nextSet.has(value);
-      if (wasChecked === isChecked) continue;
-      if (changedValue !== null) {
-        return { changedValue: null, checked: null, item: null };
-      }
-      changedValue = value;
-      checked = isChecked;
-      item = checkboxItem.el;
-    }
-    return { changedValue, checked, item };
-  };
-  const canonicalizeCheckboxValues = (
-    rawValues: readonly unknown[],
-    mode: "init" | "set",
-  ): string[] | null => {
-    const checkboxItems = getCheckboxItems().filter((item) => item.value !== null);
-    if (checkboxItems.length === 0) return null;
-    if (rawValues.length === 0) return [];
-    const requested = new Set(
-      rawValues
-        .filter((value): value is string => typeof value === "string")
-        .map((value) => value.trim())
-        .filter((value) => value.length > 0),
-    );
-    if (requested.size === 0) {
-      return mode === "init" ? [] : null;
-    }
-    const canonical: string[] = [];
-    for (const item of checkboxItems) {
-      if (item.value && requested.has(item.value)) {
-        canonical.push(item.value);
-      }
-    }
-    if (canonical.length === 0) {
-      return mode === "init" ? [] : null;
-    }
-    return canonical;
-  };
-  const syncItems = () => {
-    for (const item of items) {
-      const disabled = isItemDisabled(item);
-      item.el.setAttribute("role", getItemRole(item.type));
-      item.el.tabIndex = -1;
-      if (disabled) {
-        item.el.setAttribute("aria-disabled", "true");
-      } else {
-        item.el.removeAttribute("aria-disabled");
-      }
-      if (item.type === "radio") {
-        const checked = item.value !== null && currentValue === item.value;
-        setPresence(item.el, "data-checked", checked);
-        setAria(item.el, "checked", item.value !== null ? checked : null);
-      } else if (item.type === "checkbox") {
-        const checked = item.value !== null && currentValues.includes(item.value);
-        setPresence(item.el, "data-checked", checked);
-        setAria(item.el, "checked", item.value !== null ? checked : null);
-      } else {
-        item.el.removeAttribute("data-checked");
-        item.el.removeAttribute("aria-checked");
-      }
-    }
-    if (getRadioItems().length > 0 && currentValue !== null) {
-      root.setAttribute("data-value", currentValue);
-    } else {
-      root.removeAttribute("data-value");
-    }
-  };
-  const syncHighlightState = () => {
-    for (const item of items) {
-      setPresence(item.el, "data-highlighted", item.el === highlightedItem);
-    }
-  };
+  const syncItems = () => itemCollection.synchronizeSelection(currentValue, currentValues);
+
   const cacheItems = ({
     source = "programmatic",
     emitSelectionInvalidation = false,
   }: CacheItemsOptions = {}) => {
-    const previousItems = items;
     const previousValue = currentValue;
     const previousValues = [...currentValues];
-    itemCollection.refresh({
+    const refreshed = itemCollection.refresh({
       value: previousValue,
       values: previousValues,
       highlightedItem,
     });
-    items = [...itemCollection.items];
-    const nextValue =
-      previousValue !== null && findRadioItemByValue(previousValue) ? previousValue : null;
-    const nextValues =
-      previousValues.length > 0 ? canonicalizeCheckboxValues(previousValues, "init") ?? [] : [];
-    currentValue = nextValue;
-    currentValues = nextValues;
-    enabledItems = items.filter((item) => !isItemDisabled(item));
-    itemToEnabledIndex = new Map(enabledItems.map((item, index) => [item.el, index]));
-    if (highlightedItem && !itemToEnabledIndex.has(highlightedItem)) {
-      highlightedItem = null;
-    }
-    syncItems();
-    syncHighlightState();
+    const { previousItems } = refreshed;
+    currentValue = refreshed.value;
+    currentValues = refreshed.values;
+    highlightedItem = refreshed.highlightedItem;
+
     if (emitSelectionInvalidation) {
       if (previousValue !== currentValue) {
         emitValueChange({
           value: currentValue,
           previousValue,
-          item: currentValue === null ? null : findRadioItemByValue(currentValue)?.el ?? null,
-          previousItem: previousValue === null ? null : findRadioItemByValueIn(previousItems, previousValue)?.el ?? null,
+          item: currentValue === null ? null : itemCollection.radioFor(currentValue)?.el ?? null,
+          previousItem: previousValue === null ? null : itemCollection.radioFor(previousValue, previousItems)?.el ?? null,
           source,
         });
       }
       if (!arraysEqual(previousValues, currentValues)) {
-        const diff = getCheckboxDiff(
+        const diff = itemCollection.checkboxDiff(
           previousValues,
           currentValues,
-          previousItems.filter((item) => item.type === "checkbox"),
+          previousItems,
         );
         emitValuesChange({
           values: [...currentValues],
@@ -389,7 +298,7 @@ export function createDropdownMenu(
     nextItem: HTMLElement | null,
     { source, focus = true, focusContentOnClear = false }: HighlightUpdateOptions,
   ): boolean => {
-    if (nextItem && !itemToEnabledIndex.has(nextItem)) {
+    if (nextItem && !itemCollection.isEnabled(nextItem)) {
       return false;
     }
     const previousItem = highlightedItem;
@@ -403,7 +312,7 @@ export function createDropdownMenu(
       return false;
     }
     highlightedItem = nextItem;
-    syncHighlightState();
+    itemCollection.highlight(highlightedItem);
     if (nextItem) {
       ensureItemVisibleInContainer(nextItem, content);
       if (focus) {
@@ -413,8 +322,8 @@ export function createDropdownMenu(
       focusElement(content);
     }
     emitHighlightChange({
-      value: getResolvedValue(getItemRecord(nextItem)),
-      previousValue: getResolvedValue(getItemRecord(previousItem)),
+      value: itemCollection.valueFor(itemCollection.recordFor(nextItem)),
+      previousValue: itemCollection.valueFor(itemCollection.recordFor(previousItem)),
       item: nextItem,
       previousItem,
       source,
@@ -427,12 +336,12 @@ export function createDropdownMenu(
     emitChange = true,
   ): boolean => {
     cacheItems({ source, emitSelectionInvalidation: emitChange });
-    if (getRadioItems().length === 0) return false;
-    const nextItem = value === null ? null : findRadioItemByValue(value);
+    if (itemCollection.radios().length === 0) return false;
+    const nextItem = value === null ? null : itemCollection.radioFor(value);
     if (value !== null && !nextItem) return false;
     if (currentValue === value) return false;
     const previousValue = currentValue;
-    const previousItem = previousValue === null ? null : findRadioItemByValue(previousValue);
+    const previousItem = previousValue === null ? null : itemCollection.radioFor(previousValue);
     currentValue = value;
     syncItems();
     if (emitChange) {
@@ -452,11 +361,11 @@ export function createDropdownMenu(
     emitChange = true,
   ): boolean => {
     cacheItems({ source, emitSelectionInvalidation: emitChange });
-    const nextValues = canonicalizeCheckboxValues(values, emitChange ? "set" : "init");
+    const nextValues = itemCollection.checkboxValues(values, emitChange ? "set" : "init");
     if (nextValues === null) return false;
     if (arraysEqual(currentValues, nextValues)) return false;
     const previousValues = [...currentValues];
-    const diff = getCheckboxDiff(previousValues, nextValues);
+    const diff = itemCollection.checkboxDiff(previousValues, nextValues);
     currentValues = nextValues;
     syncItems();
     if (emitChange) {
@@ -480,7 +389,7 @@ export function createDropdownMenu(
         currentValue = null;
       }
     } else {
-      for (const radioItem of getRadioItems()) {
+      for (const radioItem of itemCollection.radios()) {
         if (radioItem.value !== null && getDataBool(radioItem.el, "defaultChecked")) {
           currentValue = radioItem.value;
           break;
@@ -488,13 +397,13 @@ export function createDropdownMenu(
       }
     }
     if (optionsHasDefaultValues || rootHasDefaultValues) {
-      const resolvedDefaults = canonicalizeCheckboxValues(requestedDefaultValues, "init");
+      const resolvedDefaults = itemCollection.checkboxValues(requestedDefaultValues, "init");
       currentValues = resolvedDefaults ?? [];
     } else {
-      const itemDefaults = getCheckboxItems()
+      const itemDefaults = itemCollection.checkboxes()
         .filter((item) => item.value !== null && getDataBool(item.el, "defaultChecked"))
         .map((item) => item.value as string);
-      currentValues = canonicalizeCheckboxValues(itemDefaults, "init") ?? [];
+      currentValues = itemCollection.checkboxValues(itemDefaults, "init") ?? [];
     }
     syncItems();
   };
@@ -561,8 +470,8 @@ export function createDropdownMenu(
     });
   };
   const activateItem = (item: DropdownMenuItemRecord, source: DropdownMenuUserSource) => {
-    if (isItemDisabled(item)) return;
-    const value = getResolvedValue(item);
+    if (itemCollection.isDisabled(item)) return;
+    const value = itemCollection.valueFor(item);
     if (value === null) return;
     let checked: boolean | undefined;
     if (item.type === "radio") {
@@ -605,14 +514,14 @@ export function createDropdownMenu(
       typeaheadBuffer = "";
     }, 500);
     typeaheadBuffer += char;
-    let matchIndex = enabledItems.findIndex((item) =>
+    let matchIndex = itemCollection.enabled.findIndex((item) =>
       (item.el.textContent?.trim().toLowerCase() ?? "").startsWith(typeaheadBuffer),
     );
     if (matchIndex === -1 && typeaheadBuffer.length === 1) {
-      const start = highlightedItem ? (itemToEnabledIndex.get(highlightedItem) ?? -1) + 1 : 0;
-      for (let i = 0; i < enabledItems.length; i++) {
-        const index = (start + i) % enabledItems.length;
-        const item = enabledItems[index];
+      const start = highlightedItem ? (itemCollection.enabledIndex(highlightedItem) ?? -1) + 1 : 0;
+      for (let i = 0; i < itemCollection.enabled.length; i++) {
+        const index = (start + i) % itemCollection.enabled.length;
+        const item = itemCollection.enabled[index];
         if ((item?.el.textContent?.trim().toLowerCase() ?? "").startsWith(char)) {
           matchIndex = index;
           break;
@@ -621,7 +530,7 @@ export function createDropdownMenu(
     }
     if (matchIndex !== -1) {
       keyboardMode = true;
-      updateHighlight(enabledItems[matchIndex]?.el ?? null, {
+      updateHighlight(itemCollection.enabled[matchIndex]?.el ?? null, {
         source: "keyboard",
         focus: true,
       });
@@ -650,7 +559,7 @@ export function createDropdownMenu(
           focusContentOnClear: true,
         });
       } else {
-        const nextItem = findItemByResolvedValue(detail.highlightedValue);
+        const nextItem = itemCollection.itemForValue(detail.highlightedValue);
         if (nextItem) {
           updateHighlight(nextItem.el, {
             source,
@@ -697,15 +606,15 @@ export function createDropdownMenu(
         });
         return;
       }
-      const itemCount = enabledItems.length;
+      const itemCount = itemCollection.enabled.length;
       if (itemCount === 0) return;
       switch (event.key) {
         case "ArrowDown":
           event.preventDefault();
           keyboardMode = true;
           updateHighlight(
-            enabledItems[
-              highlightedItem ? ((itemToEnabledIndex.get(highlightedItem) ?? -1) + 1) % itemCount : 0
+            itemCollection.enabled[
+              highlightedItem ? ((itemCollection.enabledIndex(highlightedItem) ?? -1) + 1) % itemCount : 0
             ]?.el ?? null,
             { source: "keyboard", focus: true },
           );
@@ -714,9 +623,9 @@ export function createDropdownMenu(
           event.preventDefault();
           keyboardMode = true;
           updateHighlight(
-            enabledItems[
+            itemCollection.enabled[
               highlightedItem
-                ? (itemToEnabledIndex.get(highlightedItem)! - 1 + itemCount) % itemCount
+                ? (itemCollection.enabledIndex(highlightedItem)! - 1 + itemCount) % itemCount
                 : itemCount - 1
             ]?.el ?? null,
             { source: "keyboard", focus: true },
@@ -725,7 +634,7 @@ export function createDropdownMenu(
         case "Home":
           event.preventDefault();
           keyboardMode = true;
-          updateHighlight(enabledItems[0]?.el ?? null, {
+          updateHighlight(itemCollection.enabled[0]?.el ?? null, {
             source: "keyboard",
             focus: true,
           });
@@ -733,7 +642,7 @@ export function createDropdownMenu(
         case "End":
           event.preventDefault();
           keyboardMode = true;
-          updateHighlight(enabledItems[itemCount - 1]?.el ?? null, {
+          updateHighlight(itemCollection.enabled[itemCount - 1]?.el ?? null, {
             source: "keyboard",
             focus: true,
           });
@@ -742,7 +651,7 @@ export function createDropdownMenu(
         case " ":
           event.preventDefault();
           if (highlightedItem) {
-            const highlightedRecord = getItemRecord(highlightedItem);
+            const highlightedRecord = itemCollection.recordFor(highlightedItem);
             if (highlightedRecord) {
               activateItem(highlightedRecord, "keyboard");
             }
@@ -756,21 +665,20 @@ export function createDropdownMenu(
       }
     }),
     on(content, "click", (event) => {
-      const itemEl = closestItem(event.target);
-      const item = getItemRecord(itemEl);
+      const item = itemCollection.fromTarget(event.target);
       if (!item) return;
       activateItem(item, "pointer");
     }),
     on(content, "pointermove", (event) => {
       if (!highlightItemOnHover || !isHoverPointer(event)) return;
-      const itemEl = closestItem(event.target);
+      const itemEl = itemCollection.fromTarget(event.target)?.el ?? null;
       if (keyboardMode) {
         keyboardMode = false;
         if (itemEl && itemEl === highlightedItem) {
           return;
         }
       }
-      if (itemEl && itemToEnabledIndex.has(itemEl)) {
+      if (itemEl && itemCollection.isEnabled(itemEl)) {
         updateHighlight(itemEl, {
           source: "pointer",
           focus: true,
@@ -915,7 +823,7 @@ export function createDropdownMenu(
       return [...currentValues];
     },
     get highlightedValue() {
-      return getResolvedValue(getItemRecord(highlightedItem));
+      return itemCollection.valueFor(itemCollection.recordFor(highlightedItem));
     },
     destroy: () => {
       isDestroyed = true;

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -26,284 +26,15 @@ import {
   createDismissLayer,
   containsWithPortals,
 } from "@data-slot/core";
-
-/** Side of the trigger to place the content */
-export type Side = "top" | "right" | "bottom" | "left";
+import { resolveDropdownMenuOptions } from "./dropdown-menu-options";
+import { arraysEqual, dispatchCustomEvent, getItemRole, getItemType, hasOwn, parseDefaultValues, readActionValue, readSelectableValue, setPresence } from "./dropdown-menu-items";
+export type { Align, DropdownMenuController, DropdownMenuHighlightChangeDetail, DropdownMenuItemType, DropdownMenuOpenChangeDetail, DropdownMenuOpenChangeReason, DropdownMenuOpenChangeSource, DropdownMenuOptions, DropdownMenuSelectDetail, DropdownMenuSelectionSource, DropdownMenuSetDetail, DropdownMenuSetSource, DropdownMenuUserSource, DropdownMenuValueChangeDetail, DropdownMenuValuesChangeDetail, Side } from "./dropdown-menu-types";
+import type { CacheItemsOptions, CheckboxDiff, DropdownMenuController, DropdownMenuHighlightChangeDetail, DropdownMenuItemRecord, DropdownMenuItemType, DropdownMenuOpenChangeDetail, DropdownMenuOpenChangeSource, DropdownMenuOptions, DropdownMenuSelectDetail, DropdownMenuSelectionSource, DropdownMenuSetDetail, DropdownMenuValueChangeDetail, DropdownMenuValuesChangeDetail, HighlightUpdateOptions, OpenTransitionOptions } from "./dropdown-menu-types";
 const SIDES = ["top", "right", "bottom", "left"] as const;
-
-/** Alignment of the content relative to the trigger */
-export type Align = "start" | "center" | "end";
 const ALIGNS = ["start", "center", "end"] as const;
-
-export type DropdownMenuItemType = "item" | "radio" | "checkbox";
-export type DropdownMenuUserSource = "pointer" | "keyboard";
-export type DropdownMenuSetSource = "programmatic" | "restore";
-export type DropdownMenuSelectionSource = DropdownMenuUserSource | DropdownMenuSetSource;
-export type DropdownMenuOpenChangeSource = DropdownMenuSelectionSource | "init";
-export type DropdownMenuOpenChangeReason =
-  | "trigger"
-  | "select"
-  | "outside"
-  | "escape"
-  | "tab"
-  | "programmatic"
-  | "init";
-
-export interface DropdownMenuOpenChangeDetail {
-  open: boolean;
-  previousOpen: boolean;
-  source: DropdownMenuOpenChangeSource;
-  reason: DropdownMenuOpenChangeReason;
-}
-
-export interface DropdownMenuHighlightChangeDetail {
-  value: string | null;
-  previousValue: string | null;
-  item: HTMLElement | null;
-  previousItem: HTMLElement | null;
-  source: DropdownMenuSelectionSource;
-}
-
-export interface DropdownMenuSelectDetail {
-  value: string;
-  item: HTMLElement;
-  itemType: DropdownMenuItemType;
-  source: DropdownMenuUserSource;
-  checked?: boolean;
-}
-
-export interface DropdownMenuValueChangeDetail {
-  value: string | null;
-  previousValue: string | null;
-  item: HTMLElement | null;
-  previousItem: HTMLElement | null;
-  source: DropdownMenuSelectionSource;
-}
-
-export interface DropdownMenuValuesChangeDetail {
-  values: string[];
-  previousValues: string[];
-  changedValue: string | null;
-  checked: boolean | null;
-  item: HTMLElement | null;
-  source: DropdownMenuSelectionSource;
-}
-
-export interface DropdownMenuSetDetail {
-  open?: boolean;
-  value?: string | null;
-  values?: string[];
-  highlightedValue?: string | null;
-  source?: DropdownMenuSetSource;
-}
-
-export interface DropdownMenuOptions {
-  /** Initial open state */
-  defaultOpen?: boolean;
-  /** Initial radio selection state */
-  defaultValue?: string | null;
-  /** Initial checkbox selection state */
-  defaultValues?: string[];
-  /** Callback when open state changes */
-  onOpenChange?: (open: boolean) => void;
-  /** Callback when a user activation is accepted */
-  onSelect?: (value: string) => void;
-  /** Callback when the committed radio value changes */
-  onValueChange?: (value: string | null) => void;
-  /** Callback when the committed checkbox values change */
-  onValuesChange?: (values: string[]) => void;
-  /** Close when clicking outside */
-  closeOnClickOutside?: boolean;
-  /** Close when pressing Escape */
-  closeOnEscape?: boolean;
-  /** Close when an item is selected */
-  closeOnSelect?: boolean;
-
-  // Positioning props (Radix-compatible)
-  /**
-   * The preferred side of the trigger to render against.
-   * Will be reversed when collisions occur and `avoidCollisions` is enabled.
-   * @default "bottom"
-   */
-  side?: Side;
-  /**
-   * The preferred alignment against the trigger.
-   * May change when collisions occur.
-   * @default "start"
-   */
-  align?: Align;
-  /**
-   * The distance in pixels from the trigger.
-   * @default 4
-   */
-  sideOffset?: number;
-  /**
-   * An offset in pixels from the "start" or "end" alignment options.
-   * @default 0
-   */
-  alignOffset?: number;
-  /**
-   * When true, overrides side/align preferences to prevent collisions with viewport edges.
-   * @default true
-   */
-  avoidCollisions?: boolean;
-  /**
-   * The padding between the content and the viewport edges when avoiding collisions.
-   * @default 8
-   */
-  collisionPadding?: number;
-  /**
-   * Lock body scroll when open.
-   * @default true
-   */
-  lockScroll?: boolean;
-  /**
-   * Whether moving the pointer over items should highlight and focus them.
-   * @default true
-   */
-  highlightItemOnHover?: boolean;
-}
-
-export interface DropdownMenuController {
-  /** Open the dropdown menu */
-  open(): void;
-  /** Close the dropdown menu */
-  close(): void;
-  /** Toggle the dropdown menu */
-  toggle(): void;
-  /** Set one or more dropdown menu state fields programmatically */
-  set(detail: DropdownMenuSetDetail): void;
-  /** Current open state */
-  readonly isOpen: boolean;
-  /** Current committed radio value */
-  readonly value: string | null;
-  /** Current committed checkbox values */
-  readonly values: string[];
-  /** Current highlighted value */
-  readonly highlightedValue: string | null;
-  /** Cleanup all event listeners */
-  destroy(): void;
-}
-
-interface DropdownMenuItemRecord {
-  el: HTMLElement;
-  type: DropdownMenuItemType;
-  value: string | null;
-}
-
-interface OpenTransitionOptions {
-  source: DropdownMenuOpenChangeSource;
-  reason: DropdownMenuOpenChangeReason;
-}
-
-interface HighlightUpdateOptions {
-  source: DropdownMenuSelectionSource;
-  focus?: boolean;
-  focusContentOnClear?: boolean;
-}
-
-interface CheckboxDiff {
-  changedValue: string | null;
-  checked: boolean | null;
-  item: HTMLElement | null;
-}
-
-interface CacheItemsOptions {
-  source?: DropdownMenuSelectionSource;
-  emitSelectionInvalidation?: boolean;
-}
-
 const ROOT_BINDING_KEY = "@data-slot/dropdown-menu";
-const DUPLICATE_BINDING_WARNING =
-  "[@data-slot/dropdown-menu] createDropdownMenu() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
-const ITEM_SELECTOR =
-  '[data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-checkbox-item"]';
-
-const hasOwn = <K extends string>(value: object, key: K): value is Record<K, unknown> =>
-  Object.prototype.hasOwnProperty.call(value, key);
-
-const setPresence = (el: Element, name: string, present: boolean): void => {
-  if (present) {
-    el.setAttribute(name, "");
-  } else {
-    el.removeAttribute(name);
-  }
-};
-
-const arraysEqual = (left: readonly string[], right: readonly string[]): boolean => {
-  if (left.length !== right.length) return false;
-  for (let i = 0; i < left.length; i++) {
-    if (left[i] !== right[i]) return false;
-  }
-  return true;
-};
-
-const dispatchCustomEvent = <T>(
-  el: Element,
-  name: string,
-  detail: T,
-  cancelable = false,
-): boolean => {
-  return el.dispatchEvent(
-    new CustomEvent(name, {
-      bubbles: true,
-      cancelable,
-      detail,
-    }),
-  );
-};
-
-const getItemRole = (type: DropdownMenuItemType): string => {
-  switch (type) {
-    case "radio":
-      return "menuitemradio";
-    case "checkbox":
-      return "menuitemcheckbox";
-    default:
-      return "menuitem";
-  }
-};
-
-const getItemType = (el: HTMLElement): DropdownMenuItemType => {
-  const slot = el.getAttribute("data-slot");
-  if (slot === "dropdown-menu-radio-item") return "radio";
-  if (slot === "dropdown-menu-checkbox-item") return "checkbox";
-  return "item";
-};
-
-const readSelectableValue = (el: HTMLElement): string | null => {
-  const rawValue = el.dataset["value"];
-  if (rawValue === undefined) return null;
-  const trimmed = rawValue.trim();
-  return trimmed.length > 0 ? trimmed : null;
-};
-
-const readActionValue = (item: DropdownMenuItemRecord): string => {
-  if (item.type !== "item") {
-    return item.value ?? "";
-  }
-  if (item.value) {
-    return item.value;
-  }
-  return item.el.textContent?.trim() ?? "";
-};
-
-const parseDefaultValues = (raw: string | undefined): string[] => {
-  if (raw === undefined) return [];
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return [];
-  try {
-    const parsed = JSON.parse(trimmed);
-    if (!Array.isArray(parsed)) return [];
-    return parsed
-      .filter((value): value is string => typeof value === "string")
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0);
-  } catch {
-    return [];
-  }
-};
-
+const DUPLICATE_BINDING_WARNING = "[@data-slot/dropdown-menu] createDropdownMenu() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
+const ITEM_SELECTOR = '[data-slot="dropdown-menu-item"], [data-slot="dropdown-menu-radio-item"], [data-slot="dropdown-menu-checkbox-item"]';
 /**
  * Create a dropdown menu controller for a root element.
  *
@@ -342,7 +73,6 @@ export function createDropdownMenu(
   if (existingController) {
     return existingController;
   }
-
   const trigger = getPart<HTMLElement>(root, "dropdown-menu-trigger");
   const content = getPart<HTMLElement>(root, "dropdown-menu-content");
   const authoredPositionerCandidate = getPart<HTMLElement>(root, "dropdown-menu-positioner");
@@ -355,58 +85,14 @@ export function createDropdownMenu(
     authoredPortalCandidate && authoredPositioner && authoredPortalCandidate.contains(authoredPositioner)
       ? authoredPortalCandidate
       : null;
-
   if (!trigger || !content) {
     throw new Error("DropdownMenu requires trigger and content slots");
   }
-
-  const defaultOpen = options.defaultOpen ?? getDataBool(root, "defaultOpen") ?? false;
+  const { defaultOpen, closeOnClickOutside, closeOnEscape, closeOnSelect, preferredSide, preferredAlign, sideOffset, alignOffset, avoidCollisions, collisionPadding, lockScroll: lockScrollOption, highlightItemOnHover, optionsHasDefaultValue, optionsHasDefaultValues, rootHasDefaultValue, rootHasDefaultValues, requestedDefaultValue, requestedDefaultValues } = resolveDropdownMenuOptions(root, content, authoredPositioner, options);
   const onOpenChange = options.onOpenChange;
   const onSelect = options.onSelect;
   const onValueChange = options.onValueChange;
   const onValuesChange = options.onValuesChange;
-  const closeOnClickOutside = options.closeOnClickOutside ?? getDataBool(root, "closeOnClickOutside") ?? true;
-  const closeOnEscape = options.closeOnEscape ?? getDataBool(root, "closeOnEscape") ?? true;
-  const closeOnSelect = options.closeOnSelect ?? getDataBool(root, "closeOnSelect") ?? true;
-
-  const getPlacementEnum = <T extends string>(key: string, allowed: readonly T[]): T | undefined =>
-    getDataEnum(content, key, allowed) ??
-    (authoredPositioner ? getDataEnum(authoredPositioner, key, allowed) : undefined) ??
-    getDataEnum(root, key, allowed);
-  const getPlacementNumber = (key: string): number | undefined =>
-    getDataNumber(content, key) ??
-    (authoredPositioner ? getDataNumber(authoredPositioner, key) : undefined) ??
-    getDataNumber(root, key);
-  const getPlacementBool = (key: string): boolean | undefined =>
-    getDataBool(content, key) ??
-    (authoredPositioner ? getDataBool(authoredPositioner, key) : undefined) ??
-    getDataBool(root, key);
-
-  const preferredSide = options.side ?? getPlacementEnum("side", SIDES) ?? "bottom";
-  const preferredAlign = options.align ?? getPlacementEnum("align", ALIGNS) ?? "start";
-  const sideOffset = options.sideOffset ?? getPlacementNumber("sideOffset") ?? 4;
-  const alignOffset = options.alignOffset ?? getPlacementNumber("alignOffset") ?? 0;
-  const avoidCollisions = options.avoidCollisions ?? getPlacementBool("avoidCollisions") ?? true;
-  const collisionPadding = options.collisionPadding ?? getPlacementNumber("collisionPadding") ?? 8;
-  const lockScrollOption = options.lockScroll ?? getDataBool(root, "lockScroll") ?? true;
-  const highlightItemOnHover =
-    options.highlightItemOnHover ?? getDataBool(root, "highlightItemOnHover") ?? true;
-
-  const optionsHasDefaultValue = hasOwn(options, "defaultValue");
-  const optionsHasDefaultValues = hasOwn(options, "defaultValues");
-  const rootHasDefaultValue = root.hasAttribute("data-default-value");
-  const rootHasDefaultValues = root.hasAttribute("data-default-values");
-  const requestedDefaultValue = optionsHasDefaultValue
-    ? options.defaultValue ?? null
-    : rootHasDefaultValue
-      ? getDataString(root, "defaultValue") ?? null
-      : null;
-  const requestedDefaultValues = optionsHasDefaultValues
-    ? options.defaultValues ?? []
-    : rootHasDefaultValues
-      ? parseDefaultValues(getDataString(root, "defaultValues"))
-      : [];
-
   let isOpen = false;
   let currentValue: string | null = null;
   let currentValues: string[] = [];
@@ -419,7 +105,6 @@ export function createDropdownMenu(
   let isDestroyed = false;
   let pendingDismissMeta: Pick<DropdownMenuOpenChangeDetail, "source" | "reason"> | null = null;
   const cleanups: Array<() => void> = [];
-
   const portal = createPortalLifecycle({
     content,
     root,
@@ -427,11 +112,9 @@ export function createDropdownMenu(
     container: authoredPositioner ?? undefined,
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
-
   let items: DropdownMenuItemRecord[] = [];
   let enabledItems: DropdownMenuItemRecord[] = [];
   let itemToEnabledIndex = new Map<HTMLElement, number>();
-
   const isDisabledEl = (el: HTMLElement): boolean =>
     el.hasAttribute("disabled") || el.hasAttribute("data-disabled") || el.getAttribute("aria-disabled") === "true";
   const isHoverPointer = (e: PointerEvent) => e.pointerType !== "touch";
@@ -461,7 +144,6 @@ export function createDropdownMenu(
     getRadioItems().find((item) => item.value === value) ?? null;
   const findItemByResolvedValue = (value: string): DropdownMenuItemRecord | null =>
     enabledItems.find((item) => getResolvedValue(item) === value) ?? null;
-
   const getCheckboxDiff = (
     previousValues: readonly string[],
     nextValues: readonly string[],
@@ -472,7 +154,6 @@ export function createDropdownMenu(
     let changedValue: string | null = null;
     let checked: boolean | null = null;
     let item: HTMLElement | null = null;
-
     for (const checkboxItem of checkboxItems) {
       if (checkboxItem.type !== "checkbox") continue;
       const value = checkboxItem.value;
@@ -487,10 +168,8 @@ export function createDropdownMenu(
       checked = isChecked;
       item = checkboxItem.el;
     }
-
     return { changedValue, checked, item };
   };
-
   const canonicalizeCheckboxValues = (
     rawValues: readonly unknown[],
     mode: "init" | "set",
@@ -498,7 +177,6 @@ export function createDropdownMenu(
     const checkboxItems = getCheckboxItems().filter((item) => item.value !== null);
     if (checkboxItems.length === 0) return null;
     if (rawValues.length === 0) return [];
-
     const requested = new Set(
       rawValues
         .filter((value): value is string => typeof value === "string")
@@ -508,21 +186,17 @@ export function createDropdownMenu(
     if (requested.size === 0) {
       return mode === "init" ? [] : null;
     }
-
     const canonical: string[] = [];
     for (const item of checkboxItems) {
       if (item.value && requested.has(item.value)) {
         canonical.push(item.value);
       }
     }
-
     if (canonical.length === 0) {
       return mode === "init" ? [] : null;
     }
-
     return canonical;
   };
-
   const syncItems = () => {
     for (const item of items) {
       const disabled = isItemDisabled(item);
@@ -533,7 +207,6 @@ export function createDropdownMenu(
       } else {
         item.el.removeAttribute("aria-disabled");
       }
-
       if (item.type === "radio") {
         const checked = item.value !== null && currentValue === item.value;
         setPresence(item.el, "data-checked", checked);
@@ -547,20 +220,17 @@ export function createDropdownMenu(
         item.el.removeAttribute("aria-checked");
       }
     }
-
     if (getRadioItems().length > 0 && currentValue !== null) {
       root.setAttribute("data-value", currentValue);
     } else {
       root.removeAttribute("data-value");
     }
   };
-
   const syncHighlightState = () => {
     for (const item of items) {
       setPresence(item.el, "data-highlighted", item.el === highlightedItem);
     }
   };
-
   const cacheItems = ({
     source = "programmatic",
     emitSelectionInvalidation = false,
@@ -568,31 +238,24 @@ export function createDropdownMenu(
     const previousItems = items;
     const previousValue = currentValue;
     const previousValues = [...currentValues];
-
     items = Array.from(content.querySelectorAll<HTMLElement>(ITEM_SELECTOR)).map((el) => ({
       el,
       type: getItemType(el),
       value: readSelectableValue(el),
     }));
-
     const nextValue =
       previousValue !== null && findRadioItemByValue(previousValue) ? previousValue : null;
     const nextValues =
       previousValues.length > 0 ? canonicalizeCheckboxValues(previousValues, "init") ?? [] : [];
-
     currentValue = nextValue;
     currentValues = nextValues;
-
     enabledItems = items.filter((item) => !isItemDisabled(item));
     itemToEnabledIndex = new Map(enabledItems.map((item, index) => [item.el, index]));
-
     if (highlightedItem && !itemToEnabledIndex.has(highlightedItem)) {
       highlightedItem = null;
     }
-
     syncItems();
     syncHighlightState();
-
     if (emitSelectionInvalidation) {
       if (previousValue !== currentValue) {
         emitValueChange({
@@ -603,7 +266,6 @@ export function createDropdownMenu(
           source,
         });
       }
-
       if (!arraysEqual(previousValues, currentValues)) {
         const diff = getCheckboxDiff(
           previousValues,
@@ -621,28 +283,23 @@ export function createDropdownMenu(
       }
     }
   };
-
   const emitOpenChange = (detail: DropdownMenuOpenChangeDetail) => {
     emit(root, "dropdown-menu:open-change", detail);
     // TODO(next-major): remove deprecated dropdown-menu:change alias.
     emit(root, "dropdown-menu:change", detail);
     onOpenChange?.(detail.open);
   };
-
   const emitHighlightChange = (detail: DropdownMenuHighlightChangeDetail) => {
     emit(root, "dropdown-menu:highlight-change", detail);
   };
-
   const emitValueChange = (detail: DropdownMenuValueChangeDetail) => {
     emit(root, "dropdown-menu:value-change", detail);
     onValueChange?.(detail.value);
   };
-
   const emitValuesChange = (detail: DropdownMenuValuesChangeDetail) => {
     emit(root, "dropdown-menu:values-change", detail);
     onValuesChange?.([...detail.values]);
   };
-
   const updatePosition = () => {
     const positioner = portal.container as HTMLElement;
     const win = root.ownerDocument.defaultView ?? window;
@@ -665,7 +322,6 @@ export function createDropdownMenu(
       popupX: position.x,
       popupY: position.y,
     });
-
     if (lockScrollOption) {
       positioner.style.position = "fixed";
       positioner.style.top = "0px";
@@ -677,7 +333,6 @@ export function createDropdownMenu(
       positioner.style.left = "0px";
       positioner.style.transform = `translate3d(${position.x + win.scrollX}px, ${position.y + win.scrollY}px, 0)`;
     }
-
     positioner.style.setProperty("--transform-origin", transformOrigin);
     positioner.style.willChange = "transform";
     positioner.style.margin = "0";
@@ -688,14 +343,12 @@ export function createDropdownMenu(
       positioner.setAttribute("data-align", position.align);
     }
   };
-
   const positionSync = createPositionSync({
     observedElements: [trigger, content],
     isActive: () => isOpen,
     ancestorScroll: lockScrollOption,
     onUpdate: updatePosition,
   });
-
   const restoreFocus = () => {
     requestAnimationFrame(() => {
       if (previousActiveElement && document.contains(previousActiveElement)) {
@@ -706,7 +359,6 @@ export function createDropdownMenu(
       previousActiveElement = null;
     });
   };
-
   const presence = createPresenceLifecycle({
     element: content,
     onExitComplete: () => {
@@ -716,7 +368,6 @@ export function createDropdownMenu(
       restoreFocus();
     },
   });
-
   const setDataState = (state: "open" | "closed") => {
     root.setAttribute("data-state", state);
     content.setAttribute("data-state", state);
@@ -732,7 +383,6 @@ export function createDropdownMenu(
       content.removeAttribute("data-open");
     }
   };
-
   const updateHighlight = (
     nextItem: HTMLElement | null,
     { source, focus = true, focusContentOnClear = false }: HighlightUpdateOptions,
@@ -740,7 +390,6 @@ export function createDropdownMenu(
     if (nextItem && !itemToEnabledIndex.has(nextItem)) {
       return false;
     }
-
     const previousItem = highlightedItem;
     if (previousItem === nextItem) {
       if (nextItem && focus) {
@@ -751,10 +400,8 @@ export function createDropdownMenu(
       }
       return false;
     }
-
     highlightedItem = nextItem;
     syncHighlightState();
-
     if (nextItem) {
       ensureItemVisibleInContainer(nextItem, content);
       if (focus) {
@@ -763,7 +410,6 @@ export function createDropdownMenu(
     } else if (focusContentOnClear) {
       focusElement(content);
     }
-
     emitHighlightChange({
       value: getResolvedValue(getItemRecord(nextItem)),
       previousValue: getResolvedValue(getItemRecord(previousItem)),
@@ -773,7 +419,6 @@ export function createDropdownMenu(
     });
     return true;
   };
-
   const applyRadioValue = (
     value: string | null,
     source: DropdownMenuSelectionSource,
@@ -781,16 +426,13 @@ export function createDropdownMenu(
   ): boolean => {
     cacheItems({ source, emitSelectionInvalidation: emitChange });
     if (getRadioItems().length === 0) return false;
-
     const nextItem = value === null ? null : findRadioItemByValue(value);
     if (value !== null && !nextItem) return false;
     if (currentValue === value) return false;
-
     const previousValue = currentValue;
     const previousItem = previousValue === null ? null : findRadioItemByValue(previousValue);
     currentValue = value;
     syncItems();
-
     if (emitChange) {
       emitValueChange({
         value: currentValue,
@@ -800,10 +442,8 @@ export function createDropdownMenu(
         source,
       });
     }
-
     return true;
   };
-
   const applyCheckboxValues = (
     values: readonly string[],
     source: DropdownMenuSelectionSource,
@@ -813,12 +453,10 @@ export function createDropdownMenu(
     const nextValues = canonicalizeCheckboxValues(values, emitChange ? "set" : "init");
     if (nextValues === null) return false;
     if (arraysEqual(currentValues, nextValues)) return false;
-
     const previousValues = [...currentValues];
     const diff = getCheckboxDiff(previousValues, nextValues);
     currentValues = nextValues;
     syncItems();
-
     if (emitChange) {
       emitValuesChange({
         values: [...currentValues],
@@ -829,13 +467,10 @@ export function createDropdownMenu(
         source,
       });
     }
-
     return true;
   };
-
   const initializeSelectionState = () => {
     cacheItems();
-
     if (optionsHasDefaultValue || rootHasDefaultValue) {
       if (requestedDefaultValue !== null) {
         applyRadioValue(requestedDefaultValue, "programmatic", false);
@@ -850,7 +485,6 @@ export function createDropdownMenu(
         }
       }
     }
-
     if (optionsHasDefaultValues || rootHasDefaultValues) {
       const resolvedDefaults = canonicalizeCheckboxValues(requestedDefaultValues, "init");
       currentValues = resolvedDefaults ?? [];
@@ -860,14 +494,11 @@ export function createDropdownMenu(
         .map((item) => item.value as string);
       currentValues = canonicalizeCheckboxValues(itemDefaults, "init") ?? [];
     }
-
     syncItems();
   };
-
   const updateOpenState = (open: boolean, { source, reason }: OpenTransitionOptions) => {
     if (isOpen === open) return;
     pendingDismissMeta = null;
-
     const previousOpen = isOpen;
     if (open) {
       previousActiveElement = document.activeElement as HTMLElement | null;
@@ -877,12 +508,10 @@ export function createDropdownMenu(
       content.hidden = false;
       setDataState("open");
       presence.enter();
-
       if (lockScrollOption && !didLockScroll) {
         lockScroll();
         didLockScroll = true;
       }
-
       cacheItems({
         source: source === "restore" ? "restore" : "programmatic",
         emitSelectionInvalidation: source !== "init",
@@ -906,16 +535,13 @@ export function createDropdownMenu(
       }
       typeaheadBuffer = "";
       keyboardMode = false;
-
       if (didLockScroll) {
         unlockScroll();
         didLockScroll = false;
       }
-
       positionSync.stop();
       presence.exit();
     }
-
     emitOpenChange({
       open: isOpen,
       previousOpen,
@@ -923,7 +549,6 @@ export function createDropdownMenu(
       reason,
     });
   };
-
   const setPendingDismissReason = (source: DropdownMenuUserSource, reason: "outside" | "escape") => {
     const nextMeta: Pick<DropdownMenuOpenChangeDetail, "source" | "reason"> = { source, reason };
     pendingDismissMeta = nextMeta;
@@ -933,19 +558,16 @@ export function createDropdownMenu(
       }
     });
   };
-
   const activateItem = (item: DropdownMenuItemRecord, source: DropdownMenuUserSource) => {
     if (isItemDisabled(item)) return;
     const value = getResolvedValue(item);
     if (value === null) return;
-
     let checked: boolean | undefined;
     if (item.type === "radio") {
       checked = true;
     } else if (item.type === "checkbox" && item.value !== null) {
       checked = !currentValues.includes(item.value);
     }
-
     const proceed = dispatchCustomEvent<DropdownMenuSelectDetail>(
       root,
       "dropdown-menu:select",
@@ -959,9 +581,7 @@ export function createDropdownMenu(
       true,
     );
     if (!proceed) return;
-
     onSelect?.(value);
-
     if (item.type === "radio") {
       applyRadioValue(item.value, source, true);
     } else if (item.type === "checkbox" && item.value !== null) {
@@ -973,24 +593,19 @@ export function createDropdownMenu(
       }
       applyCheckboxValues([...nextValues], source, true);
     }
-
     if (closeOnSelect) {
       updateOpenState(false, { source, reason: "select" });
     }
   };
-
   const handleTypeahead = (char: string) => {
     if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
     typeaheadTimeout = setTimeout(() => {
       typeaheadBuffer = "";
     }, 500);
-
     typeaheadBuffer += char;
-
     let matchIndex = enabledItems.findIndex((item) =>
       (item.el.textContent?.trim().toLowerCase() ?? "").startsWith(typeaheadBuffer),
     );
-
     if (matchIndex === -1 && typeaheadBuffer.length === 1) {
       const start = highlightedItem ? (itemToEnabledIndex.get(highlightedItem) ?? -1) + 1 : 0;
       for (let i = 0; i < enabledItems.length; i++) {
@@ -1002,7 +617,6 @@ export function createDropdownMenu(
         }
       }
     }
-
     if (matchIndex !== -1) {
       keyboardMode = true;
       updateHighlight(enabledItems[matchIndex]?.el ?? null, {
@@ -1011,7 +625,6 @@ export function createDropdownMenu(
       });
     }
   };
-
   const applySet = (detail: DropdownMenuSetDetail) => {
     const source = detail.source ?? "programmatic";
     if (detail.value !== undefined) {
@@ -1045,7 +658,6 @@ export function createDropdownMenu(
       }
     }
   };
-
   const triggerId = ensureId(trigger, "dropdown-menu-trigger");
   const contentId = ensureId(content, "dropdown-menu-content");
   trigger.setAttribute("aria-haspopup", "menu");
@@ -1056,9 +668,7 @@ export function createDropdownMenu(
   setAria(trigger, "expanded", false);
   content.hidden = true;
   setDataState("closed");
-
   initializeSelectionState();
-
   cleanups.push(
     on(trigger, "click", () => {
       updateOpenState(!isOpen, {
@@ -1076,7 +686,6 @@ export function createDropdownMenu(
       }
     }),
   );
-
   cleanups.push(
     on(content, "keydown", (event) => {
       if (event.key === "Tab") {
@@ -1086,10 +695,8 @@ export function createDropdownMenu(
         });
         return;
       }
-
       const itemCount = enabledItems.length;
       if (itemCount === 0) return;
-
       switch (event.key) {
         case "ArrowDown":
           event.preventDefault();
@@ -1154,7 +761,6 @@ export function createDropdownMenu(
     }),
     on(content, "pointermove", (event) => {
       if (!highlightItemOnHover || !isHoverPointer(event)) return;
-
       const itemEl = closestItem(event.target);
       if (keyboardMode) {
         keyboardMode = false;
@@ -1162,7 +768,6 @@ export function createDropdownMenu(
           return;
         }
       }
-
       if (itemEl && itemToEnabledIndex.has(itemEl)) {
         updateHighlight(itemEl, {
           source: "pointer",
@@ -1185,7 +790,6 @@ export function createDropdownMenu(
       });
     }),
   );
-
   const doc = root.ownerDocument ?? document;
   cleanups.push(
     on(
@@ -1222,7 +826,6 @@ export function createDropdownMenu(
       { capture: true },
     ),
   );
-
   cleanups.push(
     createDismissLayer({
       root,
@@ -1246,19 +849,16 @@ export function createDropdownMenu(
       closeOnEscape,
     }),
   );
-
   cleanups.push(
     on(root, "dropdown-menu:set", (event) => {
       const detail = (event as CustomEvent).detail;
       if (!detail || typeof detail !== "object") return;
-
       const nextDetail: DropdownMenuSetDetail = {
         source:
           detail.source === "restore" || detail.source === "programmatic"
             ? detail.source
             : undefined,
       };
-
       if (detail.open !== undefined) {
         nextDetail.open = detail.open;
       }
@@ -1273,7 +873,6 @@ export function createDropdownMenu(
             ? detail.highlightedValue
             : undefined;
       }
-
       if (detail.value !== undefined) {
         if (typeof detail.value === "boolean" && detail.open === undefined) {
           // TODO(next-major): remove deprecated dropdown-menu:set { value: boolean } compatibility.
@@ -1282,11 +881,9 @@ export function createDropdownMenu(
           nextDetail.value = detail.value;
         }
       }
-
       applySet(nextDetail);
     }),
   );
-
   const controller: DropdownMenuController = {
     open: () =>
       updateOpenState(true, {
@@ -1333,19 +930,15 @@ export function createDropdownMenu(
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };
-
   setRootBinding(root, ROOT_BINDING_KEY, controller);
-
   if (defaultOpen) {
     updateOpenState(true, {
       source: "init",
       reason: "init",
     });
   }
-
   return controller;
 }
-
 /**
  * Find and bind all dropdown menu components in a scope.
  * Returns array of controllers for programmatic access.

--- a/packages/select/src/configuration.ts
+++ b/packages/select/src/configuration.ts
@@ -1,0 +1,36 @@
+import { getDataBool, getDataEnum, getDataNumber, getDataString } from "@data-slot/core";
+import type { Align, Position, SelectOptions, Side } from "./types";
+
+const SIDES = ["top", "bottom"] as const;
+const ALIGNS = ["start", "center", "end"] as const;
+const POSITIONS = ["item-aligned", "popper"] as const;
+
+/** Resolves authored configuration once, preserving the documented precedence rules. */
+export function resolveSelectConfiguration(
+  root: Element, content: HTMLElement, valueSlot: HTMLElement | null,
+  authoredPositioner: HTMLElement | null, options: SelectOptions,
+) {
+  const enumValue = <T extends string>(key: string, allowed: readonly T[]) =>
+    getDataEnum(content, key, allowed) ?? (authoredPositioner ? getDataEnum(authoredPositioner, key, allowed) : undefined) ?? getDataEnum(root, key, allowed);
+  const numberValue = (key: string) => getDataNumber(content, key) ?? (authoredPositioner ? getDataNumber(authoredPositioner, key) : undefined) ?? getDataNumber(root, key);
+  const boolValue = (key: string) => getDataBool(content, key) ?? (authoredPositioner ? getDataBool(authoredPositioner, key) : undefined) ?? getDataBool(root, key);
+  return {
+    defaultValue: options.defaultValue ?? getDataString(root, "defaultValue") ?? null,
+    defaultOpen: options.defaultOpen ?? getDataBool(root, "defaultOpen") ?? false,
+    placeholder: options.placeholder ?? getDataString(root, "placeholder") ?? (valueSlot ? getDataString(valueSlot, "placeholder") : undefined) ?? "",
+    disabled: options.disabled ?? getDataBool(root, "disabled") ?? false,
+    required: options.required ?? getDataBool(root, "required") ?? false,
+    name: options.name ?? getDataString(root, "name") ?? null,
+    onValueChange: options.onValueChange,
+    onOpenChange: options.onOpenChange,
+    position: options.position ?? enumValue("position", POSITIONS) ?? "item-aligned" as Position,
+    preferredSide: options.side ?? enumValue("side", SIDES) ?? "bottom" as Side,
+    preferredAlign: options.align ?? enumValue("align", ALIGNS) ?? "start" as Align,
+    sideOffset: options.sideOffset ?? numberValue("sideOffset") ?? 4,
+    alignOffset: options.alignOffset ?? numberValue("alignOffset") ?? 0,
+    avoidCollisions: options.avoidCollisions ?? boolValue("avoidCollisions") ?? true,
+    collisionPadding: options.collisionPadding ?? numberValue("collisionPadding") ?? 8,
+    lockScrollOption: options.lockScroll ?? getDataBool(root, "lockScroll") ?? true,
+    highlightItemOnHover: options.highlightItemOnHover ?? getDataBool(root, "highlightItemOnHover") ?? true,
+  };
+}

--- a/packages/select/src/discovery.ts
+++ b/packages/select/src/discovery.ts
@@ -1,0 +1,10 @@
+import { getRoots, hasRootBinding } from "@data-slot/core";
+import type { SelectController } from "./types";
+
+const ROOT_BINDING_KEY = "@data-slot/select";
+
+export function discoverSelects(scope: ParentNode, createSelect: (root: Element) => SelectController) {
+  return Array.from(getRoots(scope, "select"))
+    .filter((root) => !hasRootBinding(root, ROOT_BINDING_KEY))
+    .map(createSelect);
+}

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -9,12 +9,8 @@ import { setAria, ensureId } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
 import { lockScroll, unlockScroll } from "@data-slot/core";
 import {
-  computeFloatingPosition,
-  computeFloatingTransformOrigin,
-  measurePopupContentRect,
   ensureItemVisibleInContainer,
   focusElement,
-  createPositionSync,
   createPortalLifecycle,
   createPresenceLifecycle,
   createDismissLayer,
@@ -22,11 +18,11 @@ import {
 import type { Align, Position, SelectController, SelectOptions, Side } from "./types";
 import { resolveSelectConfiguration } from "./configuration";
 import { discoverSelects } from "./discovery";
+import { createSelectPositioning } from "./select-positioning";
 
 export type { Align, Position, SelectController, SelectOptions, Side } from "./types";
 
 const ROOT_BINDING_KEY = "@data-slot/select";
-const SIDES = ["top", "bottom"] as const;
 const DUPLICATE_BINDING_WARNING =
   "[@data-slot/select] createSelect() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
 
@@ -232,326 +228,14 @@ export function createSelect(
     );
   };
 
-  const syncResolvedPositionAttributes = (
-    alignTriggerActive = position === "item-aligned"
-  ) => {
-    content.setAttribute("data-position", position);
-    content.setAttribute("data-align-trigger", alignTriggerActive ? "true" : "false");
-
-    const viewport = getViewport();
-    if (viewport) {
-      viewport.setAttribute("data-position", position);
-    }
-  };
-
-  type ContentRect = Pick<
-    DOMRectReadOnly,
-    "top" | "right" | "bottom" | "left" | "width" | "height"
-  >;
-  type AnchorRect = Pick<DOMRectReadOnly, "top" | "left" | "right" | "bottom" | "width" | "height">;
-  type Axis = "top" | "left";
-
-  const getMeasuredRect = (element: HTMLElement | null): DOMRect | null => {
-    if (!element) return null;
-    const rect = element.getBoundingClientRect();
-    return rect.width > 0 || rect.height > 0 ? rect : null;
-  };
-
-  const getTriggerAlignmentRect = (triggerRect: DOMRect): AnchorRect => {
-    const valueRect = getMeasuredRect(valueSlot);
-    return valueRect ?? triggerRect;
-  };
-
-  const getOffsetInAncestorPaddingBox = (
-    item: HTMLElement,
-    ancestor: HTMLElement,
-    ancestorRect: ContentRect,
-    scrollOffset: number,
-    axis: Axis
-  ) => {
-    // Prefer offset-parent traversal when the ancestor is in the chain, and
-    // fall back to rect math otherwise (e.g. before final layout settles).
-    const offsetKey = axis === "top" ? "offsetTop" : "offsetLeft";
-    const clientKey = axis === "top" ? "clientTop" : "clientLeft";
-    const rectKey = axis === "top" ? "top" : "left";
-
-    let offset = 0;
-    let node: HTMLElement | null = item;
-    while (node && node !== ancestor) {
-      offset += node[offsetKey];
-      const offsetParent: Element | null = node.offsetParent;
-      if (!(offsetParent instanceof HTMLElement)) {
-        offset = Number.NaN;
-        break;
-      }
-      if (offsetParent !== ancestor) {
-        offset += offsetParent[clientKey];
-      }
-      node = offsetParent;
-    }
-    if (node === ancestor && Number.isFinite(offset)) {
-      return offset;
-    }
-
-    const itemRect = item.getBoundingClientRect();
-    return itemRect[rectKey] - ancestorRect[rectKey] - ancestor[clientKey] + scrollOffset;
-  };
-
-  const getOffsetInAncestorBorderBox = (
-    item: HTMLElement,
-    ancestor: HTMLElement,
-    ancestorRect: ContentRect,
-    scrollOffset: number,
-    axis: Axis
-  ) =>
-    getOffsetInAncestorPaddingBox(item, ancestor, ancestorRect, scrollOffset, axis) +
-    (axis === "top" ? ancestor.clientTop : ancestor.clientLeft);
-
-  const getItemTopInContent = (
-    item: HTMLElement,
-    cr: ContentRect,
-    scrollContainer: HTMLElement
-  ) => getOffsetInAncestorBorderBox(item, content, cr, scrollContainer.scrollTop, "top");
-
-  const getItemAlignmentAnchor = (item: HTMLElement): HTMLElement => {
-    const itemText = getItemText(item);
-    if (getMeasuredRect(itemText)) {
-      return itemText!;
-    }
-    return item;
-  };
-
-  // Compute base position data for item-aligned mode
-  const computeItemAlignedPos = (tr: DOMRect, cr: ContentRect, scrollContainer: HTMLElement) => {
-    // Prefer selected item for stable anchoring, then highlighted, then first enabled item.
-    const highlightedItem = highlightedIndex >= 0 ? enabledItems[highlightedIndex] : undefined;
-    const selectedItem = items.find((item) => item.dataset["value"] === currentValue);
-    const alignItem = selectedItem ?? highlightedItem ?? enabledItems[0];
-    const triggerAlignmentRect = getTriggerAlignmentRect(tr);
-    const valueRect = getMeasuredRect(valueSlot);
-
-    // Calculate x position (align left edges, match trigger width)
-    let x = tr.left;
-
-    // Calculate y position so aligned item is at trigger's vertical center.
-    // This is the base (unclamped) y when content scrollTop is 0.
-    let y: number;
-    let anchorTopInContent = 0;
-    let anchorHeight = triggerAlignmentRect.height;
-    if (alignItem) {
-      const itemText = getItemText(alignItem);
-      const hasExactTextAlignment = Boolean(valueRect && getMeasuredRect(itemText));
-      const alignAnchor = hasExactTextAlignment && itemText ? itemText : getItemAlignmentAnchor(alignItem);
-      const alignAnchorRect = getMeasuredRect(alignAnchor) ?? alignAnchor.getBoundingClientRect();
-      anchorTopInContent = getItemTopInContent(alignAnchor, cr, scrollContainer);
-      anchorHeight =
-        alignAnchorRect.height ||
-        alignAnchor.offsetHeight ||
-        alignItem.getBoundingClientRect().height ||
-        alignItem.offsetHeight ||
-        triggerAlignmentRect.height;
-
-      if (hasExactTextAlignment && valueRect) {
-        x = valueRect.left - (alignAnchorRect.left - cr.left);
-      }
-
-      // Position content so the item's center aligns from the content padding box.
-      y =
-        triggerAlignmentRect.top +
-        (triggerAlignmentRect.height / 2) -
-        anchorTopInContent -
-        (anchorHeight / 2);
-    } else {
-      // No items at all - align top of content with trigger
-      y = tr.top;
-    }
-
-    return {
-      x,
-      y,
-      alignItem,
-      anchorTopInContent,
-      anchorHeight,
-      triggerAlignmentRect,
-    };
-  };
-
-  const updatePosition = () => {
-    const positioner = portal.container as HTMLElement;
-    const win = root.ownerDocument.defaultView ?? window;
-    const tr = trigger.getBoundingClientRect();
-    const scrollContainer = getScrollContainer();
-
-    // Set min-width to match trigger width
-    content.style.minWidth = `${tr.width}px`;
-
-    // Get content rect after setting min-width
-    const cr = measurePopupContentRect(content);
-
-    let pos: { x: number; y: number };
-    let side: Side = "bottom";
-    let transformOrigin: string;
-    let alignTriggerActive = position === "item-aligned";
-
-    if (position === "item-aligned") {
-      const computedStyles = win.getComputedStyle(content);
-      const minHeight = Number.parseFloat(computedStyles.minHeight) || 0;
-      const triggerCollisionThreshold = 20;
-      const availableHeight = Math.max(0, win.innerHeight - collisionPadding * 2);
-      const hasTriggerGeometry = tr.width > 0 || tr.height > 0;
-      const nearViewportEdge =
-        hasTriggerGeometry &&
-        (tr.top < collisionPadding + triggerCollisionThreshold ||
-          tr.bottom > win.innerHeight - collisionPadding - triggerCollisionThreshold);
-      const heightTooConstrained =
-        cr.height > 0 &&
-        ((scrollContainer.scrollHeight <= scrollContainer.clientHeight &&
-          cr.height > availableHeight + 0.5) ||
-          (minHeight > 0 &&
-            availableHeight + 0.5 <
-              Math.min(scrollContainer.scrollHeight || cr.height, minHeight)));
-
-      if (nearViewportEdge || heightTooConstrained) {
-        alignTriggerActive = false;
-        const floating = computeFloatingPosition({
-          anchorRect: tr,
-          contentRect: cr,
-          side: preferredSide,
-          align: preferredAlign,
-          sideOffset,
-          alignOffset,
-          avoidCollisions,
-          collisionPadding,
-          allowedSides: SIDES,
-        });
-        pos = { x: floating.x, y: floating.y };
-        side = floating.side as Side;
-        transformOrigin = computeFloatingTransformOrigin({
-          side,
-          align: floating.align,
-          anchorRect: tr,
-          popupX: pos.x,
-          popupY: pos.y,
-        });
-      } else {
-        const aligned = computeItemAlignedPos(tr, cr, scrollContainer);
-        pos = { x: aligned.x, y: aligned.y };
-        const triggerCenterX =
-          aligned.triggerAlignmentRect.left + (aligned.triggerAlignmentRect.width / 2);
-        const triggerCenterY =
-          aligned.triggerAlignmentRect.top + (aligned.triggerAlignmentRect.height / 2);
-        const minY = collisionPadding;
-        const maxY = win.innerHeight - cr.height - collisionPadding;
-        const clampY = (value: number) =>
-          avoidCollisions
-            ? (maxY < minY ? minY : Math.min(Math.max(value, minY), maxY))
-            : value;
-        const minX = collisionPadding;
-        const maxX = win.innerWidth - cr.width - collisionPadding;
-        const clampX = (value: number) =>
-          avoidCollisions
-            ? (maxX < minX ? minX : Math.min(Math.max(value, minX), maxX))
-            : value;
-
-        pos.x = clampX(pos.x);
-
-        if (aligned.alignItem) {
-          const maxScrollTop = Math.max(
-            0,
-            scrollContainer.scrollHeight - scrollContainer.clientHeight
-          );
-          const getTriggerCenterInContent = (currentY: number) =>
-            triggerCenterY - currentY;
-          const getDesiredScrollTop = (currentY: number) =>
-            aligned.anchorTopInContent +
-            (aligned.anchorHeight / 2) -
-            getTriggerCenterInContent(currentY);
-          if (maxScrollTop > 0) {
-            // Keep popup near the trigger and use internal scroll to align.
-            pos.y = clampY(triggerCenterY - (cr.height / 2));
-            let scrollTop = Math.min(Math.max(getDesiredScrollTop(pos.y), 0), maxScrollTop);
-            scrollContainer.scrollTop = scrollTop;
-            pos.y = clampY(
-              triggerCenterY -
-                (aligned.anchorTopInContent - scrollTop + (aligned.anchorHeight / 2))
-            );
-            scrollTop = Math.min(Math.max(getDesiredScrollTop(pos.y), 0), maxScrollTop);
-            scrollContainer.scrollTop = scrollTop;
-            pos.y = clampY(
-              triggerCenterY -
-                (aligned.anchorTopInContent - scrollTop + (aligned.anchorHeight / 2))
-            );
-          } else {
-            // No internal scrolling: align directly from item geometry.
-            scrollContainer.scrollTop = 0;
-            pos.y = clampY(aligned.y);
-          }
-        } else {
-          scrollContainer.scrollTop = 0;
-          pos.y = clampY(aligned.y);
-        }
-
-        // Determine effective side based on final position
-        side = pos.y < tr.top ? "top" : "bottom";
-
-        const originX = Math.min(Math.max(triggerCenterX - pos.x, 0), cr.width);
-        const originY = Math.min(Math.max(triggerCenterY - pos.y, 0), cr.height);
-        transformOrigin = `${originX}px ${originY}px`;
-      }
-    } else {
-      const floating = computeFloatingPosition({
-        anchorRect: tr,
-        contentRect: cr,
-        side: preferredSide,
-        align: preferredAlign,
-        sideOffset,
-        alignOffset,
-        avoidCollisions,
-        collisionPadding,
-        allowedSides: SIDES,
-      });
-      pos = { x: floating.x, y: floating.y };
-      side = floating.side as Side;
-      transformOrigin = computeFloatingTransformOrigin({
-        side,
-        align: floating.align,
-        anchorRect: tr,
-        popupX: pos.x,
-        popupY: pos.y,
-      });
-    }
-    const resolvedAlign: Align =
-      position === "item-aligned" && alignTriggerActive ? "center" : preferredAlign;
-
-    if (lockScrollOption) {
-      positioner.style.position = "fixed";
-      positioner.style.top = "0px";
-      positioner.style.left = "0px";
-      positioner.style.transform = `translate3d(${pos.x}px, ${pos.y}px, 0)`;
-    } else {
-      positioner.style.position = "absolute";
-      positioner.style.top = "0px";
-      positioner.style.left = "0px";
-      positioner.style.transform = `translate3d(${pos.x + win.scrollX}px, ${pos.y + win.scrollY}px, 0)`;
-    }
-    positioner.style.setProperty("--transform-origin", transformOrigin);
-    positioner.style.willChange = "transform";
-    positioner.style.margin = "0";
-    syncResolvedPositionAttributes(alignTriggerActive);
-    content.setAttribute("data-side", side);
-    content.setAttribute("data-align", resolvedAlign);
-    if (positioner !== content) {
-      positioner.setAttribute("data-side", side);
-      positioner.setAttribute("data-align", resolvedAlign);
-    }
-  };
-
-  const positionSync = createPositionSync({
-    observedElements: [trigger, content],
-    isActive: () => isOpen,
-    ancestorScroll: lockScrollOption,
-    onUpdate: updatePosition,
-    ignoreScrollTarget: (target) => target instanceof Node && content.contains(target),
+  const positioning = createSelectPositioning({
+    root, trigger, content, valueSlot,
+    getPositioner: () => portal.container as HTMLElement,
+    getViewport,
+    isOpen: () => isOpen,
+    getCollection: () => ({ items, enabledItems, highlightedIndex, value: currentValue }),
+    position, preferredSide, preferredAlign, sideOffset, alignOffset, avoidCollisions,
+    collisionPadding, lockScroll: lockScrollOption,
   });
 
   const updateHighlight = (index: number, focus = true, ensureVisible = true) => {
@@ -680,16 +364,16 @@ export function createSelect(
         clearHighlight();
       }
 
-      positionSync.start();
-      updatePosition();
-      positionSync.update();
+      positioning.start();
+      positioning.update();
+      positioning.sync();
 
       // Use rAF to refine position after browser has fully rendered content,
       // and to highlight item under cursor if pointer opened the select
       requestAnimationFrame(() => {
         if (!isOpen) return;
-        updatePosition();
-        positionSync.update();
+        positioning.update();
+        positioning.sync();
 
         // Highlight item under cursor if pointer opened the select
         if (
@@ -729,7 +413,7 @@ export function createSelect(
         didLockScroll = false;
       }
 
-      positionSync.stop();
+      positioning.stop();
       if (immediate) {
         presence.cleanup();
         finishClose();
@@ -884,7 +568,7 @@ export function createSelect(
   // Initialize
   setAria(trigger, "expanded", false);
   content.hidden = true;
-  syncResolvedPositionAttributes();
+  positioning.syncResolvedPositionAttributes();
   setDataState("closed");
 
   // Initial value display
@@ -970,7 +654,7 @@ export function createSelect(
     destroy: () => {
       isDestroyed = true;
       if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
-      positionSync.stop();
+      positioning.stop();
       presence.cleanup();
       portal.cleanup();
       // Unlock scroll if still locked

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -1,15 +1,9 @@
 import {
   getPart,
   getParts,
-  getRoots,
-  hasRootBinding,
   reuseRootBinding,
   setRootBinding,
   clearRootBinding,
-  getDataBool,
-  getDataNumber,
-  getDataString,
-  getDataEnum,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
@@ -25,120 +19,24 @@ import {
   createPresenceLifecycle,
   createDismissLayer,
 } from "@data-slot/core";
+import type { Align, Position, SelectController, SelectOptions, Side } from "./types";
+import { resolveSelectConfiguration } from "./configuration";
+import { discoverSelects } from "./discovery";
 
-/** Side of the trigger to place the content */
-export type Side = "top" | "bottom";
-const SIDES = ["top", "bottom"] as const;
-
-/** Alignment of the content relative to the trigger */
-export type Align = "start" | "center" | "end";
-const ALIGNS = ["start", "center", "end"] as const;
-
-/** Positioning mode for the content */
-export type Position = "item-aligned" | "popper";
-const POSITIONS = ["item-aligned", "popper"] as const;
-
-export interface SelectOptions {
-  /** Initial selected value */
-  defaultValue?: string;
-  /** Callback when value changes */
-  onValueChange?: (value: string | null) => void;
-  /** Initial open state */
-  defaultOpen?: boolean;
-  /** Callback when open state changes */
-  onOpenChange?: (open: boolean) => void;
-  /** Placeholder text when no value selected */
-  placeholder?: string;
-  /** Disable interaction */
-  disabled?: boolean;
-  /** Form validation required */
-  required?: boolean;
-  /** Form field name (auto-creates hidden input) */
-  name?: string;
-
-  /**
-   * Positioning mode for the content.
-   * - "item-aligned": Positions content so selected item aligns with trigger (like native select)
-   * - "popper": Positions content below/above trigger like a dropdown
-   * @default "item-aligned"
-   */
-  position?: Position;
-
-  // Positioning props (Radix-compatible, used when position="popper")
-  /**
-   * The preferred side of the trigger to render against.
-   * Will be reversed when collisions occur and `avoidCollisions` is enabled.
-   * @default "bottom"
-   */
-  side?: Side;
-  /**
-   * The preferred alignment against the trigger.
-   * May change when collisions occur.
-   * @default "start"
-   */
-  align?: Align;
-  /**
-   * The distance in pixels from the trigger.
-   * @default 4
-   */
-  sideOffset?: number;
-  /**
-   * An offset in pixels from the "start" or "end" alignment options.
-   * @default 0
-   */
-  alignOffset?: number;
-  /**
-   * When true, overrides side/align preferences to prevent collisions with viewport edges.
-   * @default true
-   */
-  avoidCollisions?: boolean;
-  /**
-   * The padding between the content and the viewport edges when avoiding collisions.
-   * @default 8
-   */
-  collisionPadding?: number;
-  /**
-   * Lock body scroll when open.
-   * @default true
-   */
-  lockScroll?: boolean;
-  /**
-   * Whether moving the pointer over items should highlight and focus them.
-   * @default true
-   */
-  highlightItemOnHover?: boolean;
-}
-
-export interface SelectController {
-  /** Current selected value */
-  readonly value: string | null;
-  /** Current open state */
-  readonly isOpen: boolean;
-  /** Select a value programmatically */
-  select(value: string): void;
-  /** Open the popup */
-  open(): void;
-  /** Close the popup */
-  close(): void;
-  /** Cleanup all event listeners */
-  destroy(): void;
-}
+export type { Align, Position, SelectController, SelectOptions, Side } from "./types";
 
 const ROOT_BINDING_KEY = "@data-slot/select";
+const SIDES = ["top", "bottom"] as const;
 const DUPLICATE_BINDING_WARNING =
   "[@data-slot/select] createSelect() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
 
-/**
- * Create a select controller for a root element.
- *
- * Supports Radix-compatible positioning props for precise placement:
+/** Creates a select controller for a root element. Positioning supports:
  * - `side`: "top" | "bottom" (default: "bottom")
  * - `align`: "start" | "center" | "end" (default: "start")
  * - `sideOffset`: distance from trigger in px (default: 4)
  * - `alignOffset`: offset from alignment edge in px (default: 0)
  * - `avoidCollisions`: flip/shift to stay in viewport (default: true)
  * - `collisionPadding`: viewport edge padding in px (default: 8)
- *
  * ## Events
  * - **Outbound** `select:change` (on root): Fires when value changes.
  *   `event.detail: { value: string | null }`
@@ -178,65 +76,11 @@ export function createSelect(
     throw new Error("Select requires trigger and content slots");
   }
 
-  // Resolve options with explicit precedence: JS > data-* (root, then valueSlot) > default
-  const defaultValue = options.defaultValue ?? getDataString(root, "defaultValue") ?? null;
-  const defaultOpen = options.defaultOpen ?? getDataBool(root, "defaultOpen") ?? false;
-  // Check root first, then valueSlot for placeholder (some implementations put it on the span)
-  const placeholder = options.placeholder ?? getDataString(root, "placeholder") ?? (valueSlot ? getDataString(valueSlot, "placeholder") : undefined) ?? "";
-  const disabled = options.disabled ?? getDataBool(root, "disabled") ?? false;
-  const required = options.required ?? getDataBool(root, "required") ?? false;
-  const name = options.name ?? getDataString(root, "name") ?? null;
-  const onValueChange = options.onValueChange;
-  const onOpenChange = options.onOpenChange;
-
-  // Placement precedence: JS option > content > authored positioner > root
-  const getPlacementEnum = <T extends string>(key: string, allowed: readonly T[]): T | undefined =>
-    getDataEnum(content, key, allowed) ??
-    (authoredPositioner ? getDataEnum(authoredPositioner, key, allowed) : undefined) ??
-    getDataEnum(root, key, allowed);
-  const getPlacementNumber = (key: string): number | undefined =>
-    getDataNumber(content, key) ??
-    (authoredPositioner ? getDataNumber(authoredPositioner, key) : undefined) ??
-    getDataNumber(root, key);
-  const getPlacementBool = (key: string): boolean | undefined =>
-    getDataBool(content, key) ??
-    (authoredPositioner ? getDataBool(authoredPositioner, key) : undefined) ??
-    getDataBool(root, key);
-
-  // Position mode
-  const position =
-    options.position ??
-    getPlacementEnum("position", POSITIONS) ??
-    "item-aligned";
-
-  // Placement options (used for popper mode)
-  const preferredSide =
-    options.side ??
-    getPlacementEnum("side", SIDES) ??
-    "bottom";
-  const preferredAlign =
-    options.align ??
-    getPlacementEnum("align", ALIGNS) ??
-    "start";
-  const sideOffset =
-    options.sideOffset ??
-    getPlacementNumber("sideOffset") ??
-    4;
-  const alignOffset =
-    options.alignOffset ??
-    getPlacementNumber("alignOffset") ??
-    0;
-  const avoidCollisions =
-    options.avoidCollisions ??
-    getPlacementBool("avoidCollisions") ??
-    true;
-  const collisionPadding =
-    options.collisionPadding ??
-    getPlacementNumber("collisionPadding") ??
-    8;
-  const lockScrollOption = options.lockScroll ?? getDataBool(root, "lockScroll") ?? true;
-  const highlightItemOnHover =
-    options.highlightItemOnHover ?? getDataBool(root, "highlightItemOnHover") ?? true;
+  const {
+    defaultValue, defaultOpen, placeholder, disabled, required, name, onValueChange, onOpenChange,
+    position, preferredSide, preferredAlign, sideOffset, alignOffset, avoidCollisions,
+    collisionPadding, lockScrollOption, highlightItemOnHover,
+  } = resolveSelectConfiguration(root, content, valueSlot, authoredPositioner, options);
 
   let isOpen = false;
   let currentValue: string | null = defaultValue;
@@ -1150,15 +994,6 @@ export function createSelect(
   return controller;
 }
 
-/**
- * Find and bind all select components in a scope
- * Returns array of controllers for programmatic access
- */
 export function create(scope: ParentNode = document): SelectController[] {
-  const controllers: SelectController[] = [];
-  for (const root of getRoots(scope, "select")) {
-    if (hasRootBinding(root, ROOT_BINDING_KEY)) continue;
-    controllers.push(createSelect(root));
-  }
-  return controllers;
+  return discoverSelects(scope, createSelect);
 }

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -15,7 +15,7 @@ import {
   createPresenceLifecycle,
   createDismissLayer,
 } from "@data-slot/core";
-import type { Align, Position, SelectController, SelectOptions, Side } from "./types";
+import type { SelectController, SelectOptions } from "./types";
 import { resolveSelectConfiguration } from "./configuration";
 import { discoverSelects } from "./discovery";
 import { createSelectPositioning } from "./select-positioning";

--- a/packages/select/src/select-positioning.ts
+++ b/packages/select/src/select-positioning.ts
@@ -1,0 +1,377 @@
+import {
+  computeFloatingPosition,
+  computeFloatingTransformOrigin,
+  createPositionSync,
+  measurePopupContentRect,
+} from "@data-slot/core";
+import type { Align, Position, Side } from "./types";
+
+const SIDES = ["top", "bottom"] as const;
+
+type ContentRect = Pick<
+  DOMRectReadOnly,
+  "top" | "right" | "bottom" | "left" | "width" | "height"
+>;
+type AnchorRect = Pick<
+  DOMRectReadOnly,
+  "top" | "left" | "right" | "bottom" | "width" | "height"
+>;
+type Axis = "top" | "left";
+
+type CollectionSnapshot = {
+  items: HTMLElement[];
+  enabledItems: HTMLElement[];
+  highlightedIndex: number;
+  value: string | null;
+};
+
+type SelectPositioningOptions = {
+  root: Element;
+  trigger: HTMLElement;
+  content: HTMLElement;
+  valueSlot: HTMLElement | null;
+  getPositioner: () => HTMLElement;
+  getViewport: () => HTMLElement | null;
+  isOpen: () => boolean;
+  getCollection: () => CollectionSnapshot;
+  position: Position;
+  preferredSide: Side;
+  preferredAlign: Align;
+  sideOffset: number;
+  alignOffset: number;
+  avoidCollisions: boolean;
+  collisionPadding: number;
+  lockScroll: boolean;
+};
+
+/** Owns select popup geometry, item alignment, and resize/scroll position syncing. */
+export function createSelectPositioning(options: SelectPositioningOptions) {
+  const {
+    root,
+    trigger,
+    content,
+    valueSlot,
+    getPositioner,
+    getViewport,
+    isOpen,
+    getCollection,
+    position,
+    preferredSide,
+    preferredAlign,
+    sideOffset,
+    alignOffset,
+    avoidCollisions,
+    collisionPadding,
+    lockScroll,
+  } = options;
+  const getScrollContainer = () => getViewport() ?? content;
+  const getItemText = (item: HTMLElement) =>
+    item.querySelector<HTMLElement>('[data-slot="select-item-text"]');
+  const getMeasuredRect = (element: HTMLElement | null) => {
+    if (!element) return null;
+    const rect = element.getBoundingClientRect();
+    return rect.width > 0 || rect.height > 0 ? rect : null;
+  };
+  const syncResolvedPositionAttributes = (
+    alignTriggerActive = position === "item-aligned",
+  ) => {
+    content.setAttribute("data-position", position);
+    content.setAttribute(
+      "data-align-trigger",
+      alignTriggerActive ? "true" : "false",
+    );
+    getViewport()?.setAttribute("data-position", position);
+  };
+  const getTriggerAlignmentRect = (triggerRect: DOMRect): AnchorRect =>
+    getMeasuredRect(valueSlot) ?? triggerRect;
+  const getOffsetInAncestorPaddingBox = (
+    item: HTMLElement,
+    ancestor: HTMLElement,
+    ancestorRect: ContentRect,
+    scrollOffset: number,
+    axis: Axis,
+  ) => {
+    const offsetKey = axis === "top" ? "offsetTop" : "offsetLeft";
+    const clientKey = axis === "top" ? "clientTop" : "clientLeft";
+    const rectKey = axis === "top" ? "top" : "left";
+    let offset = 0;
+    let node: HTMLElement | null = item;
+    while (node && node !== ancestor) {
+      offset += node[offsetKey];
+      const offsetParent: Element | null = node.offsetParent;
+      if (!(offsetParent instanceof HTMLElement)) {
+        offset = Number.NaN;
+        break;
+      }
+      if (offsetParent !== ancestor) offset += offsetParent[clientKey];
+      node = offsetParent;
+    }
+    if (node === ancestor && Number.isFinite(offset)) return offset;
+    const itemRect = item.getBoundingClientRect();
+    return (
+      itemRect[rectKey] -
+      ancestorRect[rectKey] -
+      ancestor[clientKey] +
+      scrollOffset
+    );
+  };
+  const getItemTopInContent = (
+    item: HTMLElement,
+    cr: ContentRect,
+    scrollContainer: HTMLElement,
+  ) =>
+    getOffsetInAncestorPaddingBox(
+      item,
+      content,
+      cr,
+      scrollContainer.scrollTop,
+      "top",
+    ) + content.clientTop;
+  const getItemAlignmentAnchor = (item: HTMLElement) => {
+    const itemText = getItemText(item);
+    return getMeasuredRect(itemText) ? itemText! : item;
+  };
+  const computeItemAlignedPos = (
+    tr: DOMRect,
+    cr: ContentRect,
+    scrollContainer: HTMLElement,
+  ) => {
+    const { items, enabledItems, highlightedIndex, value } = getCollection();
+    const highlightedItem =
+      highlightedIndex >= 0 ? enabledItems[highlightedIndex] : undefined;
+    const selectedItem = items.find((item) => item.dataset["value"] === value);
+    const alignItem = selectedItem ?? highlightedItem ?? enabledItems[0];
+    const triggerAlignmentRect = getTriggerAlignmentRect(tr);
+    const valueRect = getMeasuredRect(valueSlot);
+    let x = tr.left;
+    let y: number;
+    let anchorTopInContent = 0;
+    let anchorHeight = triggerAlignmentRect.height;
+    if (alignItem) {
+      const itemText = getItemText(alignItem);
+      const hasExactTextAlignment = Boolean(
+        valueRect && getMeasuredRect(itemText),
+      );
+      const alignAnchor =
+        hasExactTextAlignment && itemText
+          ? itemText
+          : getItemAlignmentAnchor(alignItem);
+      const alignAnchorRect =
+        getMeasuredRect(alignAnchor) ?? alignAnchor.getBoundingClientRect();
+      anchorTopInContent = getItemTopInContent(
+        alignAnchor,
+        cr,
+        scrollContainer,
+      );
+      anchorHeight =
+        alignAnchorRect.height ||
+        alignAnchor.offsetHeight ||
+        alignItem.getBoundingClientRect().height ||
+        alignItem.offsetHeight ||
+        triggerAlignmentRect.height;
+      if (hasExactTextAlignment && valueRect)
+        x = valueRect.left - (alignAnchorRect.left - cr.left);
+      y =
+        triggerAlignmentRect.top +
+        triggerAlignmentRect.height / 2 -
+        anchorTopInContent -
+        anchorHeight / 2;
+    } else y = tr.top;
+    return {
+      x,
+      y,
+      alignItem,
+      anchorTopInContent,
+      anchorHeight,
+      triggerAlignmentRect,
+    };
+  };
+  const update = () => {
+    const positioner = getPositioner();
+    const win = root.ownerDocument.defaultView ?? window;
+    const tr = trigger.getBoundingClientRect();
+    const scrollContainer = getScrollContainer();
+    content.style.minWidth = `${tr.width}px`;
+    const cr = measurePopupContentRect(content);
+    let pos: { x: number; y: number };
+    let side: Side = "bottom";
+    let transformOrigin: string;
+    let alignTriggerActive = position === "item-aligned";
+    if (position === "item-aligned") {
+      const minHeight =
+        Number.parseFloat(win.getComputedStyle(content).minHeight) || 0;
+      const availableHeight = Math.max(
+        0,
+        win.innerHeight - collisionPadding * 2,
+      );
+      const hasTriggerGeometry = tr.width > 0 || tr.height > 0;
+      const nearViewportEdge =
+        hasTriggerGeometry &&
+        (tr.top < collisionPadding + 20 ||
+          tr.bottom > win.innerHeight - collisionPadding - 20);
+      const heightTooConstrained =
+        cr.height > 0 &&
+        ((scrollContainer.scrollHeight <= scrollContainer.clientHeight &&
+          cr.height > availableHeight + 0.5) ||
+          (minHeight > 0 &&
+            availableHeight + 0.5 <
+              Math.min(scrollContainer.scrollHeight || cr.height, minHeight)));
+      if (nearViewportEdge || heightTooConstrained) {
+        alignTriggerActive = false;
+        const floating = computeFloatingPosition({
+          anchorRect: tr,
+          contentRect: cr,
+          side: preferredSide,
+          align: preferredAlign,
+          sideOffset,
+          alignOffset,
+          avoidCollisions,
+          collisionPadding,
+          allowedSides: SIDES,
+        });
+        pos = { x: floating.x, y: floating.y };
+        side = floating.side as Side;
+        transformOrigin = computeFloatingTransformOrigin({
+          side,
+          align: floating.align,
+          anchorRect: tr,
+          popupX: pos.x,
+          popupY: pos.y,
+        });
+      } else {
+        const aligned = computeItemAlignedPos(tr, cr, scrollContainer);
+        pos = { x: aligned.x, y: aligned.y };
+        const triggerCenterX =
+          aligned.triggerAlignmentRect.left +
+          aligned.triggerAlignmentRect.width / 2;
+        const triggerCenterY =
+          aligned.triggerAlignmentRect.top +
+          aligned.triggerAlignmentRect.height / 2;
+        const clamp = (value: number, minimum: number, maximum: number) =>
+          avoidCollisions
+            ? maximum < minimum
+              ? minimum
+              : Math.min(Math.max(value, minimum), maximum)
+            : value;
+        pos.x = clamp(
+          pos.x,
+          collisionPadding,
+          win.innerWidth - cr.width - collisionPadding,
+        );
+        if (aligned.alignItem) {
+          const maxScrollTop = Math.max(
+            0,
+            scrollContainer.scrollHeight - scrollContainer.clientHeight,
+          );
+          const desiredScrollTop = (currentY: number) =>
+            aligned.anchorTopInContent +
+            aligned.anchorHeight / 2 -
+            (triggerCenterY - currentY);
+          if (maxScrollTop > 0) {
+            pos.y = clamp(
+              triggerCenterY - cr.height / 2,
+              collisionPadding,
+              win.innerHeight - cr.height - collisionPadding,
+            );
+            let scrollTop = Math.min(
+              Math.max(desiredScrollTop(pos.y), 0),
+              maxScrollTop,
+            );
+            scrollContainer.scrollTop = scrollTop;
+            pos.y = clamp(
+              triggerCenterY -
+                (aligned.anchorTopInContent -
+                  scrollTop +
+                  aligned.anchorHeight / 2),
+              collisionPadding,
+              win.innerHeight - cr.height - collisionPadding,
+            );
+            scrollTop = Math.min(
+              Math.max(desiredScrollTop(pos.y), 0),
+              maxScrollTop,
+            );
+            scrollContainer.scrollTop = scrollTop;
+            pos.y = clamp(
+              triggerCenterY -
+                (aligned.anchorTopInContent -
+                  scrollTop +
+                  aligned.anchorHeight / 2),
+              collisionPadding,
+              win.innerHeight - cr.height - collisionPadding,
+            );
+          } else {
+            scrollContainer.scrollTop = 0;
+            pos.y = clamp(
+              aligned.y,
+              collisionPadding,
+              win.innerHeight - cr.height - collisionPadding,
+            );
+          }
+        } else {
+          scrollContainer.scrollTop = 0;
+          pos.y = clamp(
+            aligned.y,
+            collisionPadding,
+            win.innerHeight - cr.height - collisionPadding,
+          );
+        }
+        side = pos.y < tr.top ? "top" : "bottom";
+        transformOrigin = `${Math.min(Math.max(triggerCenterX - pos.x, 0), cr.width)}px ${Math.min(Math.max(triggerCenterY - pos.y, 0), cr.height)}px`;
+      }
+    } else {
+      const floating = computeFloatingPosition({
+        anchorRect: tr,
+        contentRect: cr,
+        side: preferredSide,
+        align: preferredAlign,
+        sideOffset,
+        alignOffset,
+        avoidCollisions,
+        collisionPadding,
+        allowedSides: SIDES,
+      });
+      pos = { x: floating.x, y: floating.y };
+      side = floating.side as Side;
+      transformOrigin = computeFloatingTransformOrigin({
+        side,
+        align: floating.align,
+        anchorRect: tr,
+        popupX: pos.x,
+        popupY: pos.y,
+      });
+    }
+    const resolvedAlign: Align =
+      position === "item-aligned" && alignTriggerActive
+        ? "center"
+        : preferredAlign;
+    positioner.style.position = lockScroll ? "fixed" : "absolute";
+    positioner.style.top = "0px";
+    positioner.style.left = "0px";
+    positioner.style.transform = `translate3d(${pos.x + (lockScroll ? 0 : win.scrollX)}px, ${pos.y + (lockScroll ? 0 : win.scrollY)}px, 0)`;
+    positioner.style.setProperty("--transform-origin", transformOrigin);
+    positioner.style.willChange = "transform";
+    positioner.style.margin = "0";
+    syncResolvedPositionAttributes(alignTriggerActive);
+    content.setAttribute("data-side", side);
+    content.setAttribute("data-align", resolvedAlign);
+    if (positioner !== content) {
+      positioner.setAttribute("data-side", side);
+      positioner.setAttribute("data-align", resolvedAlign);
+    }
+  };
+  const sync = createPositionSync({
+    observedElements: [trigger, content],
+    isActive: isOpen,
+    ancestorScroll: lockScroll,
+    onUpdate: update,
+    ignoreScrollTarget: (target) =>
+      target instanceof Node && content.contains(target),
+  });
+  return {
+    update,
+    start: () => sync.start(),
+    stop: () => sync.stop(),
+    sync: () => sync.update(),
+    syncResolvedPositionAttributes,
+  };
+}

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -1,0 +1,37 @@
+/** Side of the trigger to place the content. */
+export type Side = "top" | "bottom";
+
+/** Alignment of the content relative to the trigger. */
+export type Align = "start" | "center" | "end";
+
+/** Positioning mode for the content. */
+export type Position = "item-aligned" | "popper";
+
+export interface SelectOptions {
+  defaultValue?: string;
+  onValueChange?: (value: string | null) => void;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  name?: string;
+  position?: Position;
+  side?: Side;
+  align?: Align;
+  sideOffset?: number;
+  alignOffset?: number;
+  avoidCollisions?: boolean;
+  collisionPadding?: number;
+  lockScroll?: boolean;
+  highlightItemOnHover?: boolean;
+}
+
+export interface SelectController {
+  readonly value: string | null;
+  readonly isOpen: boolean;
+  select(value: string): void;
+  open(): void;
+  close(): void;
+  destroy(): void;
+}

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -1,37 +1,94 @@
-/** Side of the trigger to place the content. */
+/** Side of the trigger to place the content */
 export type Side = "top" | "bottom";
 
-/** Alignment of the content relative to the trigger. */
+/** Alignment of the content relative to the trigger */
 export type Align = "start" | "center" | "end";
 
-/** Positioning mode for the content. */
+/** Positioning mode for the content */
 export type Position = "item-aligned" | "popper";
 
 export interface SelectOptions {
+  /** Initial selected value */
   defaultValue?: string;
+  /** Callback when value changes */
   onValueChange?: (value: string | null) => void;
+  /** Initial open state */
   defaultOpen?: boolean;
+  /** Callback when open state changes */
   onOpenChange?: (open: boolean) => void;
+  /** Placeholder text when no value selected */
   placeholder?: string;
+  /** Disable interaction */
   disabled?: boolean;
+  /** Form validation required */
   required?: boolean;
+  /** Form field name (auto-creates hidden input) */
   name?: string;
+
+  /**
+   * Positioning mode for the content.
+   * - "item-aligned": Positions content so selected item aligns with trigger (like native select)
+   * - "popper": Positions content below/above trigger like a dropdown
+   * @default "item-aligned"
+   */
   position?: Position;
+
+  // Positioning props (Radix-compatible, used when position="popper")
+  /**
+   * The preferred side of the trigger to render against.
+   * Will be reversed when collisions occur and `avoidCollisions` is enabled.
+   * @default "bottom"
+   */
   side?: Side;
+  /**
+   * The preferred alignment against the trigger.
+   * May change when collisions occur.
+   * @default "start"
+   */
   align?: Align;
+  /**
+   * The distance in pixels from the trigger.
+   * @default 4
+   */
   sideOffset?: number;
+  /**
+   * An offset in pixels from the "start" or "end" alignment options.
+   * @default 0
+   */
   alignOffset?: number;
+  /**
+   * When true, overrides side/align preferences to prevent collisions with viewport edges.
+   * @default true
+   */
   avoidCollisions?: boolean;
+  /**
+   * The padding between the content and the viewport edges when avoiding collisions.
+   * @default 8
+   */
   collisionPadding?: number;
+  /**
+   * Lock body scroll when open.
+   * @default true
+   */
   lockScroll?: boolean;
+  /**
+   * Whether moving the pointer over items should highlight and focus them.
+   * @default true
+   */
   highlightItemOnHover?: boolean;
 }
 
 export interface SelectController {
+  /** Current selected value */
   readonly value: string | null;
+  /** Current open state */
   readonly isOpen: boolean;
+  /** Select a value programmatically */
   select(value: string): void;
+  /** Open the popup */
   open(): void;
+  /** Close the popup */
   close(): void;
+  /** Cleanup all event listeners */
   destroy(): void;
 }

--- a/packages/slider/src/slider-math.ts
+++ b/packages/slider/src/slider-math.ts
@@ -8,47 +8,6 @@ export type VisualPercents = {
   trackPercent: number;
 };
 
-export interface SliderOptions {
-  /** Initial value(s) - number or [min, max] for range */
-  defaultValue?: number | [number, number];
-  /** Minimum value */
-  min?: number;
-  /** Maximum value */
-  max?: number;
-  /** Step increment */
-  step?: number;
-  /** Larger step for PageUp/PageDown/Shift+Arrow */
-  largeStep?: number;
-  /** Slider orientation */
-  orientation?: "horizontal" | "vertical";
-  /**
-   * Thumb alignment when the value is at the track edges.
-   * "edge-client-only" is accepted for Base UI compatibility and behaves the same as "edge".
-   */
-  thumbAlignment?: ThumbAlignment;
-  /** Disable the slider */
-  disabled?: boolean;
-  /** Callback when value changes during interaction */
-  onValueChange?: (value: number | [number, number]) => void;
-  /** Callback when interaction ends (pointer release, blur) */
-  onValueCommit?: (value: number | [number, number]) => void;
-}
-
-export interface SliderController {
-  /** Set value programmatically */
-  setValue(value: number | [number, number]): void;
-  /** Current value(s) */
-  readonly value: number | [number, number];
-  /** Min value */
-  readonly min: number;
-  /** Max value */
-  readonly max: number;
-  /** Whether slider is disabled */
-  readonly disabled: boolean;
-  /** Cleanup all event listeners */
-  destroy(): void;
-}
-
 /**
  * Parse a default value from string (e.g., "50" or "25,75")
  */


### PR DESCRIPTION
## Summary

**TL;DR:** Move collection behavior and select positioning out of large component controllers. The controllers keep event handling and lifecycle coordination; the extracted modules own item discovery, lookup, filtering, selection reconciliation, and geometry. Public APIs and observable behavior are intended to remain compatible with `main`.

The diff touches 19 files (+1,560 / −1,800 lines), mostly moved code. Review the final diff by responsibility in the order below.

## Suggested review order

1. **Start with the behavior contracts.** The new [combobox tests](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/combobox/src/index.test.ts#L977) cover all three disabled attributes for pointer and keyboard selection, plus re-enabling an item while open (seven cases). The [dropdown tests](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/dropdown-menu/src/index.test.ts#L597) cover clearing the last checkbox by click and `set({ values: [] })` (two cases).

2. **Dropdown collection and controller handoff — highest review priority.** Read [dropdown-menu-items.ts](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/dropdown-menu/src/dropdown-menu-items.ts#L25), then [cacheItems in the controller](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/dropdown-menu/src/index.ts#L154). The collection owns the item caches, enabled index, selection normalization, and item ARIA updates. The controller consumes the reconciled state and emits events. Check that removed selections retain the correct previous-item references and event details; existing [invalidation coverage](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/dropdown-menu/src/index.test.ts#L718) exercises this boundary. An empty checkbox array clears selection; invalid nonempty input must not accidentally clear it.

3. **Combobox collection and activation.** Read [combobox-collection.ts](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/combobox/src/combobox-collection.ts#L31), then [selectItem](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/combobox/src/index.ts#L469). Filtering, labels, selected state, and highlighting move into the collection. Activation still reads the current disabled attributes: a cached navigation index must not decide whether a newly disabled or re-enabled item can be selected.

4. **Select geometry and lifecycle wiring.** Read [select-positioning.ts](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/select/src/select-positioning.ts#L48), then its calls in `select/src/index.ts`. Check live collection snapshots, selected-item alignment, collision fallback, viewport scrolling, and start/stop/update timing. Existing select positioning and portal tests cover these paths.

5. **Command value resolution.** Read [command-collection-model.ts](https://github.com/bejamas/data-slot/blob/7f9978f4ced0615a49d28cfa1f6ec9d522dfca00/packages/command/src/command-collection-model.ts#L60), then the corresponding controller calls. Authored values must stay stable while values inferred from item text can refresh after DOM mutations; nested command ownership remains scoped to its root.

## Mechanical changes and scope

- Select/combobox configuration and discovery, dropdown options, and public type declarations move into separate files. Preserve option precedence, root binding behavior, exports, and API comments when reviewing these moves.
- `slider-math.ts` only loses duplicate `SliderOptions` and `SliderController` declarations; the public definitions remain in the slider entry point.
- No generated files, dependency changes, or migration steps are included. The popup geometry extraction already on `main` is outside this diff.

## Validation

Validated locally at `7f9978f` against base `b55ceeb`:

- `bun test`: **1,252 passed**, including the nine new regression cases above.
- Builds passed for **core, command, combobox, dropdown-menu, select, and slider**, including type declarations.
- `git diff --check` passed.
- **Full typechecking is not green.** Comparison against the same `main` base found **no new diagnostics**: 143 on this branch versus 144 on main. The removed diagnostic is an unused command constant; existing diagnostics remain.
- On GitHub, **Workers Builds: data-slot passed**; **[code]smith was skipped**. The test and typecheck results above are local validation, not additional GitHub checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/data-slot/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791543247&installation_model_id=433409&pr_number=12&repository=bejamas%2Fdata-slot&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fdata-slot%2Fpull%2F12&signature=270328b1fc81d63a9bf4409b846cf5c50a04cf59560a4b340e9e7b9ce75be386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->