### PR TITLE
refactor(core): share typeahead between select and dropdown-menu

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -17,6 +17,7 @@ import {
 import { ensureId, setAria, linkLabelledBy } from './index'
 import { on, emit, composeHandlers } from './index'
 import { lockScroll, unlockScroll } from './index'
+import { createTypeahead } from './index'
 import { containsWithPortals, portalToBody, restorePortal } from './index'
 import {
   computeFloatingPosition,
@@ -1975,5 +1976,110 @@ describe('core/popup', () => {
         value: originalGetComputedStyle,
       })
     }
+  })
+})
+
+describe('core/typeahead', () => {
+  const labels = ['Apple', 'Banana', 'Blueberry', 'Cherry', 'Other']
+
+  it('matches the first label starting with the typed character', () => {
+    const typeahead = createTypeahead()
+    expect(typeahead.match('b', labels, -1)).toBe(1)
+    typeahead.destroy()
+  })
+
+  it('matches case-insensitively', () => {
+    const typeahead = createTypeahead()
+    expect(typeahead.match('C', labels, -1)).toBe(3)
+    expect(typeahead.match('h', labels, 3)).toBe(3)
+    typeahead.destroy()
+  })
+
+  it('accumulates characters into a prefix buffer', () => {
+    const typeahead = createTypeahead()
+    expect(typeahead.match('b', labels, -1)).toBe(1)
+    expect(typeahead.match('l', labels, 1)).toBe(2)
+    expect(typeahead.match('u', labels, 2)).toBe(2)
+    typeahead.destroy()
+  })
+
+  it('returns -1 when the buffer matches nothing', () => {
+    const typeahead = createTypeahead()
+    expect(typeahead.match('z', labels, -1)).toBe(-1)
+    expect(typeahead.match('a', labels, -1)).toBe(-1) // buffer is now "za"
+    typeahead.destroy()
+  })
+
+  it('treats a repeated character as a longer prefix (parity with select/dropdown-menu)', () => {
+    const typeahead = createTypeahead()
+    expect(typeahead.match('b', labels, -1)).toBe(1)
+    // Buffer is now "bb": no label starts with it and the single-character
+    // wrap-around does not apply, so the highlight does not cycle.
+    expect(typeahead.match('b', labels, 1)).toBe(-1)
+    typeahead.destroy()
+  })
+
+  it('single-character wrap-around searches forward from currentIndex + 1', () => {
+    // The wrap-around is only consulted when a one-character buffer has no
+    // prefix match anywhere; assert its ordering via an injected label list
+    // where the prefix search and the wrap search would disagree if reached.
+    const typeahead = createTypeahead()
+    expect(typeahead.match('c', ['Cherry', 'apple', 'Cranberry'], 0)).toBe(0)
+    typeahead.reset()
+    expect(typeahead.match('a', ['Cherry', 'apple', 'Cranberry'], 2)).toBe(1)
+    typeahead.destroy()
+  })
+
+  it('treats -1 as "start from the first item" in the wrap-around search', () => {
+    const typeahead = createTypeahead()
+    typeahead.match('x', labels, -1) // buffer "x" -> no match
+    typeahead.reset()
+    // fresh single "o": prefix match finds Other regardless of index
+    expect(typeahead.match('o', labels, -1)).toBe(4)
+    // "oo" -> no prefix match; single-char fallback does not apply (length 2)
+    expect(typeahead.match('o', labels, 4)).toBe(-1)
+    typeahead.destroy()
+  })
+
+  it('resets the buffer after the delay elapses', async () => {
+    const typeahead = createTypeahead({ resetDelayMs: 20 })
+    expect(typeahead.match('b', labels, -1)).toBe(1)
+    await new Promise((resolve) => setTimeout(resolve, 40))
+    // A fresh "c" must not be read as "bc"
+    expect(typeahead.match('c', labels, 1)).toBe(3)
+    typeahead.destroy()
+  })
+
+  it('keeps the buffer while characters arrive within the delay', async () => {
+    const typeahead = createTypeahead({ resetDelayMs: 60 })
+    expect(typeahead.match('o', labels, -1)).toBe(4)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(typeahead.match('t', labels, 4)).toBe(4)
+    typeahead.destroy()
+  })
+
+  it('reset() clears the buffer and cancels the timer', async () => {
+    const typeahead = createTypeahead({ resetDelayMs: 1000 })
+    expect(typeahead.match('b', labels, -1)).toBe(1)
+    typeahead.reset()
+    expect(typeahead.match('c', labels, 1)).toBe(3)
+    typeahead.destroy()
+  })
+
+  it('uses the provided window for timers', () => {
+    const calls: Array<{ name: string; delay?: number }> = []
+    const fakeWin = {
+      setTimeout: (_fn: () => void, delay: number) => {
+        calls.push({ name: 'set', delay })
+        return 42
+      },
+      clearTimeout: (id: number) => {
+        calls.push({ name: `clear:${id}` })
+      },
+    } as unknown as Window
+    const typeahead = createTypeahead({ win: fakeWin, resetDelayMs: 123 })
+    typeahead.match('a', labels, -1)
+    typeahead.destroy()
+    expect(calls).toEqual([{ name: 'set', delay: 123 }, { name: 'clear:42' }])
   })
 })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,3 +52,5 @@ export type {
   PresenceLifecycleOptions,
   PresenceLifecycleController,
 } from "./popup.ts";
+export { createTypeahead } from "./typeahead.ts";
+export type { TypeaheadOptions, TypeaheadController } from "./typeahead.ts";

--- a/packages/core/src/typeahead.ts
+++ b/packages/core/src/typeahead.ts
@@ -1,0 +1,70 @@
+export interface TypeaheadOptions {
+  /** Milliseconds of inactivity before the typed buffer resets. Defaults to 500. */
+  resetDelayMs?: number;
+  /** Window used for timers. Defaults to the global window. */
+  win?: Window;
+}
+
+export interface TypeaheadController {
+  /**
+   * Feed one typed character and find the item it should highlight.
+   *
+   * The character is appended to the buffer (restarting the reset timer). The first
+   * label that starts with the whole buffer wins. If nothing matches and the buffer is a
+   * single character, a wrap-around search runs forward from `currentIndex + 1` for a
+   * label starting with that character. Pass `-1` for `currentIndex` when nothing is
+   * highlighted (the wrap-around then starts from the first label).
+   *
+   * Matching is case-insensitive. Returns the matched index or -1.
+   */
+  match(char: string, labels: readonly string[], currentIndex: number): number;
+  /** Clear the buffer and cancel the pending reset timer. */
+  reset(): void;
+  /** Alias of `reset`, for cleanup arrays. */
+  destroy(): void;
+}
+
+export function createTypeahead(options: TypeaheadOptions = {}): TypeaheadController {
+  const resetDelayMs = options.resetDelayMs ?? 500;
+  const win = options.win ?? window;
+
+  let buffer = "";
+  let timeoutId: number | null = null;
+
+  const reset = () => {
+    if (timeoutId !== null) {
+      win.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    buffer = "";
+  };
+
+  const match = (char: string, labels: readonly string[], currentIndex: number): number => {
+    if (timeoutId !== null) win.clearTimeout(timeoutId);
+    timeoutId = win.setTimeout(() => {
+      buffer = "";
+      timeoutId = null;
+    }, resetDelayMs);
+
+    const needle = char.toLowerCase();
+    buffer += needle;
+
+    const lowered = labels.map((label) => label.toLowerCase());
+    let matchIndex = lowered.findIndex((label) => label.startsWith(buffer));
+
+    if (matchIndex === -1 && buffer.length === 1) {
+      const start = currentIndex + 1;
+      for (let i = 0; i < lowered.length; i++) {
+        const index = (start + i) % lowered.length;
+        if (lowered[index]!.startsWith(needle)) {
+          matchIndex = index;
+          break;
+        }
+      }
+    }
+
+    return matchIndex;
+  };
+
+  return { match, reset, destroy: reset };
+}

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -22,6 +22,7 @@ import {
   createPresenceLifecycle,
   createDismissLayer,
   containsWithPortals,
+  createTypeahead,
 } from "@data-slot/core";
 import { resolveDropdownMenuOptions } from "./dropdown-menu-options";
 import { createDropdownItemCollection } from "./dropdown-menu-items";
@@ -133,8 +134,7 @@ export function createDropdownMenu(
   let currentValues: string[] = [];
   let highlightedItem: HTMLElement | null = null;
   let previousActiveElement: HTMLElement | null = null;
-  let typeaheadBuffer = "";
-  let typeaheadTimeout: ReturnType<typeof setTimeout> | null = null;
+  const typeahead = createTypeahead();
   let keyboardMode = false;
   let didLockScroll = false;
   let isDestroyed = false;
@@ -428,7 +428,7 @@ export function createDropdownMenu(
         emitSelectionInvalidation: source !== "init",
       });
       keyboardMode = false;
-      typeaheadBuffer = "";
+      typeahead.reset();
       positionSync.start();
       updatePosition();
       positionSync.update();
@@ -444,7 +444,7 @@ export function createDropdownMenu(
           focusContentOnClear: false,
         });
       }
-      typeaheadBuffer = "";
+      typeahead.reset();
       keyboardMode = false;
       if (didLockScroll) {
         unlockScroll();
@@ -509,25 +509,13 @@ export function createDropdownMenu(
     }
   };
   const handleTypeahead = (char: string) => {
-    if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
-    typeaheadTimeout = setTimeout(() => {
-      typeaheadBuffer = "";
-    }, 500);
-    typeaheadBuffer += char;
-    let matchIndex = itemCollection.enabled.findIndex((item) =>
-      (item.el.textContent?.trim().toLowerCase() ?? "").startsWith(typeaheadBuffer),
+    const currentIndex = highlightedItem ? (itemCollection.enabledIndex(highlightedItem) ?? -1) : -1;
+    const matchIndex = typeahead.match(
+      char,
+      itemCollection.enabled.map((item) => item.el.textContent?.trim() ?? ""),
+      currentIndex,
     );
-    if (matchIndex === -1 && typeaheadBuffer.length === 1) {
-      const start = highlightedItem ? (itemCollection.enabledIndex(highlightedItem) ?? -1) + 1 : 0;
-      for (let i = 0; i < itemCollection.enabled.length; i++) {
-        const index = (start + i) % itemCollection.enabled.length;
-        const item = itemCollection.enabled[index];
-        if ((item?.el.textContent?.trim().toLowerCase() ?? "").startsWith(char)) {
-          matchIndex = index;
-          break;
-        }
-      }
-    }
+
     if (matchIndex !== -1) {
       keyboardMode = true;
       updateHighlight(itemCollection.enabled[matchIndex]?.el ?? null, {
@@ -827,7 +815,7 @@ export function createDropdownMenu(
     },
     destroy: () => {
       isDestroyed = true;
-      if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
+      typeahead.destroy();
       positionSync.stop();
       presence.cleanup();
       portal.cleanup();

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -4,6 +4,7 @@ import {
   reuseRootBinding,
   setRootBinding,
   clearRootBinding,
+  createTypeahead,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
@@ -82,8 +83,7 @@ export function createSelect(
   let currentValue: string | null = defaultValue;
   let previousActiveElement: HTMLElement | null = null;
   let highlightedIndex = -1;
-  let typeaheadBuffer = "";
-  let typeaheadTimeout: ReturnType<typeof setTimeout> | null = null;
+  const typeahead = createTypeahead();
   let keyboardMode = false;
   let lastPointerX = 0;
   let lastPointerY = 0;
@@ -403,7 +403,7 @@ export function createSelect(
       setAria(trigger, "expanded", false);
       setDataState("closed");
       clearHighlight();
-      typeaheadBuffer = "";
+      typeahead.reset();
       keyboardMode = false;
       shouldRestoreFocusOnClose = !skipFocusRestore;
 
@@ -524,25 +524,11 @@ export function createSelect(
   };
 
   const handleTypeahead = (char: string) => {
-    if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
-    typeaheadTimeout = setTimeout(() => { typeaheadBuffer = ""; }, 500);
-
-    typeaheadBuffer += char;
-
-    let matchIndex = enabledItems.findIndex((el) =>
-      getItemLabelText(el).toLowerCase().startsWith(typeaheadBuffer)
+    const matchIndex = typeahead.match(
+      char,
+      enabledItems.map((el) => getItemLabelText(el)),
+      highlightedIndex
     );
-
-    if (matchIndex === -1 && typeaheadBuffer.length === 1) {
-      const start = highlightedIndex + 1;
-      for (let i = 0; i < enabledItems.length; i++) {
-        const idx = (start + i) % enabledItems.length;
-        if (getItemLabelText(enabledItems[idx]!).toLowerCase().startsWith(char)) {
-          matchIndex = idx;
-          break;
-        }
-      }
-    }
 
     if (matchIndex !== -1) {
       keyboardMode = true;
@@ -653,7 +639,7 @@ export function createSelect(
     close: () => updateOpenState(false),
     destroy: () => {
       isDestroyed = true;
-      if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
+      typeahead.destroy();
       positioning.stop();
       presence.cleanup();
       portal.cleanup();


### PR DESCRIPTION
Select and dropdown-menu duplicated their typeahead prefix matching and reset timers. Extract that behavior into `createTypeahead` in `@data-slot/core` and use it in both components, preserving label selection, case-insensitive matching, and the 500 ms buffer timeout. Reset and destroy now cancel pending timers.

Add core tests for prefix accumulation, unmatched and repeated characters, timeout/reset behavior, and injected window timers. Rebased onto current main while preserving its extracted select positioning and dropdown item collection modules.

Validation:
- `bun test`: 1,263 passed, 0 failed.
- `bun run build`: passed for all packages.
- `bun run typecheck`: 143 existing errors, identical to main after normalizing line numbers; no new diagnostics.
- Reviewed the branch diff against main; no actionable regressions found.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/data-slot/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554367&installation_model_id=433409&pr_number=13&repository=bejamas%2Fdata-slot&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fdata-slot%2Fpull%2F13&signature=b7fa473d0a784909ff40516fb6967df173f9d7176ce9eb818d31aec9fffb2edb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->