### PR TITLE
Fix native form reset and disabled submission lifecycle

### DIFF
--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -303,6 +303,21 @@ When `name` is provided, a hidden input is automatically created for form submis
 </form>
 ```
 
+An authored `name` on the combobox input is also supported. The generated input
+submits the selected value; the visible input keeps the search or display text.
+Destroying the controller removes the generated input and restores the authored name.
+
+**Behavior change:** earlier releases left an authored `name` on the visible input,
+so the form received the displayed or typed text. It now receives the selected value
+(or an empty string when nothing is selected). To submit free text, keep `name` off the
+combobox input and mirror `combobox:input-change` into a separate field.
+A disabled combobox does not submit its value.
+
+Resetting the form restores `defaultValue` and the displayed selection without
+emitting a value-change event. An open popup also resets its search and highlight.
+Synchronization happens on the next event-loop task, after the browser resets
+native controls. Calling `preventDefault()` on the reset event preserves the current state.
+
 ## License
 
 MIT

--- a/packages/combobox/src/configuration.ts
+++ b/packages/combobox/src/configuration.ts
@@ -6,7 +6,7 @@ const ALIGNS = ["start", "center", "end"] as const;
 
 /** Resolves authored configuration once, preserving the documented precedence rules. */
 export function resolveComboboxConfiguration(
-  root: Element, content: HTMLElement, authoredPositioner: HTMLElement | null, options: ComboboxOptions,
+  root: Element, input: HTMLInputElement, content: HTMLElement, authoredPositioner: HTMLElement | null, options: ComboboxOptions,
 ) {
   const enumValue = <T extends string>(key: string, allowed: readonly T[]) =>
     getDataEnum(content, key, allowed) ?? (authoredPositioner ? getDataEnum(authoredPositioner, key, allowed) : undefined) ?? getDataEnum(root, key, allowed);
@@ -18,7 +18,7 @@ export function resolveComboboxConfiguration(
     placeholder: options.placeholder ?? getDataString(root, "placeholder") ?? "",
     disabled: options.disabled ?? getDataBool(root, "disabled") ?? false,
     required: options.required ?? getDataBool(root, "required") ?? false,
-    name: options.name ?? getDataString(root, "name") ?? null,
+    name: options.name ?? getDataString(root, "name") ?? input.getAttribute("name") ?? null,
     openOnFocus: options.openOnFocus ?? getDataBool(root, "openOnFocus") ?? true,
     autoHighlight: options.autoHighlight ?? getDataBool(root, "autoHighlight") ?? false,
     customFilter: options.filter ?? null,

--- a/packages/combobox/src/index.test.ts
+++ b/packages/combobox/src/index.test.ts
@@ -1446,6 +1446,52 @@ describe("Combobox", () => {
       expect(hiddenInput.name).toBe("fruit");
       controller.destroy();
     });
+
+    it("restores initial selection, input text, and form data after reset without a second change", async () => {
+      document.body.innerHTML = `<form><div data-slot="combobox" id="root"><input data-slot="combobox-input" name="fruit" /><div data-slot="combobox-content"><div data-slot="combobox-list"><div data-slot="combobox-item" data-value="apple">Apple</div><div data-slot="combobox-item" data-value="banana">Banana</div></div></div></div></form>`;
+      const root = document.getElementById("root")!;
+      const form = root.closest("form")!;
+      let changes = 0;
+      const controller = createCombobox(root, { defaultValue: "banana", onValueChange: () => changes++ });
+      controller.select("apple");
+      form.reset();
+      await Promise.resolve();
+
+      expect(controller.value).toBe("banana");
+      expect((root.querySelector('[data-slot="combobox-input"]') as HTMLInputElement).value).toBe("Banana");
+      expect(root.querySelector('[data-value="banana"]')?.getAttribute("aria-selected")).toBe("true");
+      expect(new FormData(form).get("fruit")).toBe("banana");
+      expect(changes).toBe(1);
+      controller.destroy();
+    });
+
+    it("does not apply a canceled form reset", async () => {
+      document.body.innerHTML = `<form><div data-slot="combobox" id="root"><input data-slot="combobox-input" name="fruit" /><div data-slot="combobox-content"><div data-slot="combobox-list"><div data-slot="combobox-item" data-value="apple">Apple</div><div data-slot="combobox-item" data-value="banana">Banana</div></div></div></div></form>`;
+      const root = document.getElementById("root")!;
+      const form = root.closest("form")!;
+      const controller = createCombobox(root, { defaultValue: "banana" });
+      controller.select("apple");
+      form.addEventListener("reset", (event) => event.preventDefault());
+      form.reset();
+      await Promise.resolve();
+      expect(controller.value).toBe("apple");
+      controller.destroy();
+    });
+
+    it("restores an authored input name when destroyed and can be rebound", () => {
+      document.body.innerHTML = `<form><div data-slot="combobox" id="root"><input data-slot="combobox-input" name="fruit" /><div data-slot="combobox-content"><div data-slot="combobox-list"><div data-slot="combobox-item" data-value="apple">Apple</div></div></div></div></form>`;
+      const root = document.getElementById("root")!;
+      const input = root.querySelector('[data-slot="combobox-input"]') as HTMLInputElement;
+      const first = createCombobox(root);
+      expect(input.hasAttribute("name")).toBe(false);
+      first.destroy();
+      expect(input.name).toBe("fruit");
+      expect(root.querySelector('input[type="hidden"]')).toBeNull();
+      const second = createCombobox(root);
+      expect(input.hasAttribute("name")).toBe(false);
+      second.destroy();
+      expect(input.name).toBe("fruit");
+    });
   });
 
   describe("native label[for] support", () => {

--- a/packages/combobox/src/index.test.ts
+++ b/packages/combobox/src/index.test.ts
@@ -1381,6 +1381,114 @@ describe("Combobox", () => {
   });
 
   describe("form integration", () => {
+    it.each(["inline", "popup"] as const)("resets an open %s input's query, results, and highlight silently", async (mode) => {
+      const inputMarkup = '<input data-slot="combobox-input" name="fruit" />';
+      const valueChanges: Array<string | null> = [];
+      const inputChanges: string[] = [];
+      const openChanges: boolean[] = [];
+      const { root, input, items, emptySlot, controller } = setup({
+        defaultValue: "banana",
+        autoHighlight: true,
+        onValueChange: (value) => valueChanges.push(value),
+        onInputValueChange: (value) => inputChanges.push(value),
+        onOpenChange: (open) => openChanges.push(open),
+      }, `
+        <form>
+          <div data-slot="combobox" id="root">
+            ${mode === "inline" ? inputMarkup : ""}
+            <button data-slot="combobox-trigger"><span data-slot="combobox-value">Choose fruit</span></button>
+            <div data-slot="combobox-content">
+              ${mode === "popup" ? inputMarkup : ""}
+              <div data-slot="combobox-list">
+                <div data-slot="combobox-item" data-value="apple">Apple</div>
+                <div data-slot="combobox-item" data-value="banana">Banana</div>
+                <div data-slot="combobox-empty" hidden>No results</div>
+              </div>
+            </div>
+          </div>
+        </form>
+      `);
+      const form = root.closest("form")!;
+      const events: string[] = [];
+      for (const type of ["combobox:change", "combobox:input-change", "combobox:open-change"]) {
+        root.addEventListener(type, () => events.push(type));
+      }
+      controller.select("apple");
+      controller.open();
+      input.value = "app";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      expect(items[0]?.hasAttribute("data-highlighted")).toBe(true);
+      expect(items[1]?.hidden).toBe(true);
+
+      // Reset twice: presentation must reset even when the committed value is unchanged.
+      for (let attempt = 0; attempt < 2; attempt++) {
+        form.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(controller.value).toBe("banana");
+        expect(controller.isOpen).toBe(true);
+        expect(input.value).toBe(mode === "popup" ? "" : "Banana");
+        expect(root.querySelector('[data-slot="combobox-value"]')?.textContent).toBe("Banana");
+        expect(items[0]?.hidden).toBe(mode === "inline");
+        expect(items[1]?.hidden).toBe(false);
+        expect(items[0]?.hasAttribute("data-highlighted")).toBe(false);
+        expect(items[1]?.hasAttribute("data-highlighted")).toBe(true);
+        expect(input.getAttribute("aria-activedescendant")).toBe(items[1]?.id ?? null);
+        expect(emptySlot.hidden).toBe(true);
+        expect(new FormData(form).get("fruit")).toBe("banana");
+
+        if (attempt === 0) {
+          input.value = "app";
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+      }
+      expect(valueChanges).toEqual(["apple"]);
+      expect(inputChanges).toEqual(["app", "app"]);
+      expect(openChanges).toEqual([true]);
+      expect(events).toEqual(["combobox:change", "combobox:open-change", "combobox:input-change", "combobox:input-change"]);
+      controller.destroy();
+    });
+
+    it("clears the active descendant and empty results when an open combobox resets to no selection", async () => {
+      const { root, input, items, emptySlot, controller } = setup();
+      const form = document.createElement("form");
+      root.before(form);
+      form.appendChild(root);
+      controller.open();
+      input.value = "missing";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      expect(emptySlot.hidden).toBe(false);
+
+      form.reset();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(controller.value).toBeNull();
+      expect(input.value).toBe("");
+      expect(input.hasAttribute("aria-activedescendant")).toBe(false);
+      expect(Array.from(items).every((item) => !item.hidden && !item.hasAttribute("data-highlighted"))).toBe(true);
+      expect(emptySlot.hidden).toBe(true);
+      expect(controller.isOpen).toBe(true);
+      controller.destroy();
+    });
+
+    it("preserves an authored named input's disabled state on its form proxy", () => {
+      const { root, controller } = setup({ defaultValue: "apple" }, `
+        <form>
+          <div data-slot="combobox" id="root">
+            <input data-slot="combobox-input" name="fruit" disabled />
+            <div data-slot="combobox-content">
+              <div data-slot="combobox-item" data-value="apple">Apple</div>
+            </div>
+          </div>
+        </form>
+      `);
+      // Happy DOM's FormData includes disabled controls; assert native eligibility here.
+      const proxy = root.querySelector<HTMLInputElement>('input[type="hidden"]')!;
+      expect(proxy.name).toBe("fruit");
+      expect(proxy.disabled).toBe(true);
+      controller.destroy();
+    });
+
     it("creates hidden input when name is provided", () => {
       const { root, controller } = setup({ name: "fruit" });
       const hiddenInput = root.querySelector('input[type="hidden"]') as HTMLInputElement;
@@ -1455,7 +1563,7 @@ describe("Combobox", () => {
       const controller = createCombobox(root, { defaultValue: "banana", onValueChange: () => changes++ });
       controller.select("apple");
       form.reset();
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(controller.value).toBe("banana");
       expect((root.querySelector('[data-slot="combobox-input"]') as HTMLInputElement).value).toBe("Banana");
@@ -1473,7 +1581,7 @@ describe("Combobox", () => {
       controller.select("apple");
       form.addEventListener("reset", (event) => event.preventDefault());
       form.reset();
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(controller.value).toBe("apple");
       controller.destroy();
     });
@@ -1485,7 +1593,7 @@ describe("Combobox", () => {
       const controller = createCombobox(root, { defaultValue: "" });
       controller.select("apple");
       form.reset();
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(controller.value).toBe("");
       expect(root.querySelector('input[type="hidden"]')).toBeNull();
       controller.destroy();
@@ -1500,7 +1608,7 @@ describe("Combobox", () => {
       first.select("apple");
       expect(new FormData(form).get("fruit")).toBe("apple");
       form.reset();
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(first.value).toBe("banana");
       first.destroy();
       expect(input.name).toBe("fruit");

--- a/packages/combobox/src/index.test.ts
+++ b/packages/combobox/src/index.test.ts
@@ -1478,6 +1478,40 @@ describe("Combobox", () => {
       controller.destroy();
     });
 
+    it("resets an unnamed combobox with an empty-string default without creating a proxy", async () => {
+      document.body.innerHTML = `<form><div data-slot="combobox" id="root"><input data-slot="combobox-input" /><div data-slot="combobox-content"><div data-slot="combobox-list"><div data-slot="combobox-item" data-value="">Empty</div><div data-slot="combobox-item" data-value="apple">Apple</div></div></div></div></form>`;
+      const root = document.getElementById("root")!;
+      const form = root.closest("form")!;
+      const controller = createCombobox(root, { defaultValue: "" });
+      controller.select("apple");
+      form.reset();
+      await Promise.resolve();
+      expect(controller.value).toBe("");
+      expect(root.querySelector('input[type="hidden"]')).toBeNull();
+      controller.destroy();
+    });
+
+    it("uses and preserves an authored external form association", async () => {
+      document.body.innerHTML = `<form id="external"></form><div data-slot="combobox" id="root"><input data-slot="combobox-input" name="fruit" form="external" /><div data-slot="combobox-content"><div data-slot="combobox-list"><div data-slot="combobox-item" data-value="apple">Apple</div><div data-slot="combobox-item" data-value="banana">Banana</div></div></div></div>`;
+      const root = document.getElementById("root")!;
+      const input = root.querySelector('[data-slot="combobox-input"]') as HTMLInputElement;
+      const form = document.getElementById("external") as HTMLFormElement;
+      const first = createCombobox(root, { defaultValue: "banana" });
+      first.select("apple");
+      expect(new FormData(form).get("fruit")).toBe("apple");
+      form.reset();
+      await Promise.resolve();
+      expect(first.value).toBe("banana");
+      first.destroy();
+      expect(input.name).toBe("fruit");
+      expect(input.getAttribute("form")).toBe("external");
+      const second = createCombobox(root, { defaultValue: "banana" });
+      expect(new FormData(form).get("fruit")).toBe("banana");
+      second.destroy();
+      expect(input.name).toBe("fruit");
+      expect(input.getAttribute("form")).toBe("external");
+    });
+
     it("restores an authored input name when destroyed and can be rebound", () => {
       document.body.innerHTML = `<form><div data-slot="combobox" id="root"><input data-slot="combobox-input" name="fruit" /><div data-slot="combobox-content"><div data-slot="combobox-list"><div data-slot="combobox-item" data-value="apple">Apple</div></div></div></div></form>`;
       const root = document.getElementById("root")!;

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -15,8 +15,9 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createDismissLayer,
-  FormFieldAdapter,
+  createFormFieldAdapter,
 } from "@data-slot/core";
+import type { FormFieldAdapter } from "@data-slot/core";
 import type {
   ComboboxController,
   ComboboxItemToStringValue,
@@ -621,7 +622,7 @@ export function createCombobox(
   // Set initial value and input text
   updateValue(currentValue, true);
 
-  formField = new FormFieldAdapter({
+  formField = createFormFieldAdapter({
     root,
     name,
     defaultValue,

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -15,6 +15,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createDismissLayer,
+  FormFieldAdapter,
 } from "@data-slot/core";
 import type {
   ComboboxController,
@@ -90,10 +91,11 @@ export function createCombobox(
 
   // Resolve options: JS > data-* > defaults
   const {
-    defaultValue, defaultOpen, placeholder, disabled, required, name, openOnFocus, autoHighlight,
+    defaultValue, defaultOpen, placeholder, disabled, required, name: configuredName, openOnFocus, autoHighlight,
     customFilter, onValueChange, onOpenChange, onInputValueChange, preferredSide, preferredAlign,
     sideOffset, alignOffset, avoidCollisions, collisionPadding,
   } = resolveComboboxConfiguration(root, content, authoredPositioner, options);
+  const name = configuredName ?? input.getAttribute("name");
   let itemToStringValue = options.itemToStringValue ?? null;
 
   // State
@@ -110,8 +112,7 @@ export function createCombobox(
   let openOnNextFocusFromPointer = false;
   let suppressOpenOnNextFocus = false;
 
-  // Hidden input for form integration
-  let hiddenInput: HTMLInputElement | null = null;
+  let formField: FormFieldAdapter | null = null;
 
   // Portal lifecycle
   const portal = createPortalLifecycle({
@@ -210,15 +211,6 @@ export function createCombobox(
     }
   }
 
-  // Form integration: strip name from visible input, create hidden input
-  if (name) {
-    if (input.name) input.removeAttribute("name");
-    hiddenInput = document.createElement("input");
-    hiddenInput.type = "hidden";
-    hiddenInput.name = name;
-    hiddenInput.value = currentValue ?? "";
-    root.appendChild(hiddenInput);
-  }
 
   const collection = createComboboxCollection({
     root,
@@ -419,10 +411,7 @@ export function createCombobox(
     currentValue = value;
     syncValidity();
 
-    // Update hidden input
-    if (hiddenInput) {
-      hiddenInput.value = value ?? "";
-    }
+    formField?.setValue(value);
 
     // Update root data-value
     if (value !== null) {
@@ -632,6 +621,14 @@ export function createCombobox(
   // Set initial value and input text
   updateValue(currentValue, true);
 
+  formField = new FormFieldAdapter({
+    root,
+    name,
+    defaultValue,
+    control: input,
+    onReset: (value) => updateValue(value, true),
+  });
+
   // Event listeners
   cleanups.push(
     on(doc, "keydown", (e) => {
@@ -768,9 +765,7 @@ export function createCombobox(
       portal.cleanup();
       cleanups.forEach((fn) => fn());
       cleanups.length = 0;
-      if (hiddenInput && hiddenInput.parentNode) {
-        hiddenInput.parentNode.removeChild(hiddenInput);
-      }
+      formField?.destroy();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -92,11 +92,10 @@ export function createCombobox(
 
   // Resolve options: JS > data-* > defaults
   const {
-    defaultValue, defaultOpen, placeholder, disabled, required, name: configuredName, openOnFocus, autoHighlight,
+    defaultValue, defaultOpen, placeholder, disabled, required, name, openOnFocus, autoHighlight,
     customFilter, onValueChange, onOpenChange, onInputValueChange, preferredSide, preferredAlign,
     sideOffset, alignOffset, avoidCollisions, collisionPadding,
-  } = resolveComboboxConfiguration(root, content, authoredPositioner, options);
-  const name = configuredName ?? input.getAttribute("name");
+  } = resolveComboboxConfiguration(root, input, content, authoredPositioner, options);
   let itemToStringValue = options.itemToStringValue ?? null;
 
   // State
@@ -337,6 +336,22 @@ export function createCombobox(
     },
   });
 
+  // Shows the current results and highlights the committed value if visible.
+  const syncOpenResults = () => {
+    keyboardMode = false;
+    // In popup-input mode, input text is transient search and should start empty.
+    if (isPopupInputMode) {
+      input.value = "";
+    }
+    collection.filter(input.value);
+    const selectedIndex = collection.enabled.findIndex((item) => collection.valueOf(item) === currentValue);
+    if (selectedIndex >= 0) {
+      collection.highlight(selectedIndex);
+    } else {
+      collection.clearHighlight();
+    }
+  };
+
   const updateOpenState = (open: boolean, skipFocusRestore = false) => {
     if (isOpen === open) return;
     if (disabled && open) return;
@@ -351,23 +366,7 @@ export function createCombobox(
       presence.enter();
 
       collection.cache(currentValue);
-      keyboardMode = false;
-
-      // In popup-input mode, input text is transient search and should start empty on open.
-      if (isPopupInputMode) {
-        input.value = "";
-      }
-
-      // Apply current filter
-      collection.filter(input.value);
-
-      // Highlight selected item if visible, else auto-highlight first
-      const selectedIndex = collection.enabled.findIndex((item) => collection.valueOf(item) === currentValue);
-      if (selectedIndex >= 0) {
-        collection.highlight(selectedIndex);
-      } else {
-        collection.clearHighlight();
-      }
+      syncOpenResults();
 
       positionSync.start();
       updatePosition();
@@ -627,7 +626,14 @@ export function createCombobox(
     name,
     defaultValue,
     control: input,
-    onReset: (value) => updateValue(value, true),
+    disabled,
+    onReset: (value) => {
+      updateValue(value, true);
+      if (isOpen) {
+        syncOpenResults();
+        positionSync.update();
+      }
+    },
   });
 
   // Event listeners

--- a/packages/core/src/form-field-submission.ts
+++ b/packages/core/src/form-field-submission.ts
@@ -1,0 +1,62 @@
+import { on } from "./events.ts";
+
+/** Preserve a control's native submission eligibility when its value uses a proxy. */
+export function observeFormFieldSubmission(
+  root: Element,
+  control: HTMLInputElement,
+  proxy: HTMLInputElement,
+  disabled: boolean,
+) {
+  // The marker identifies this proxy's position without confusing it with other
+  // controls that submit the same name and value. It never reaches submitted data.
+  const marker = root.ownerDocument.createElement("input");
+  marker.type = "hidden";
+  marker.name = `data-slot-form-field-${crypto.getRandomValues(new Uint32Array(4)).join("-")}`;
+  const formAttribute = proxy.getAttribute("form");
+  if (formAttribute !== null) marker.setAttribute("form", formAttribute);
+  proxy.after(marker);
+
+  const observed = new Map<Node, () => void>();
+  const handled = new WeakSet<Event>();
+  const handleFormData = (event: Event) => {
+    if (event.target !== proxy.form || handled.has(event)) return;
+    handled.add(event);
+    observe();
+
+    const data = (event as FormDataEvent).formData;
+    const entries: Array<[string, FormDataEntryValue]> = Array.from(data.entries());
+    const markerIndex = entries.findIndex(([name]) => name === marker.name);
+    // Both inputs inherit any disabled fieldset surrounding the composite root.
+    if (markerIndex < 0) return;
+
+    const wasIncluded = !proxy.disabled;
+    const excluded = disabled || control.matches(":disabled");
+    proxy.disabled = excluded;
+
+    // A MutationObserver would run too late for `input.disabled = true;
+    // new FormData(form)`. Reconcile in the native formdata event instead.
+    const start = markerIndex - (wasIncluded ? 1 : 0);
+    entries.splice(start, wasIncluded ? 2 : 1, ...(
+      excluded ? [] : [[proxy.name, proxy.value] as [string, FormDataEntryValue]]
+    ));
+    for (const name of new Set(data.keys())) data.delete(name);
+    for (const [name, value] of entries) data.append(name, value);
+  };
+
+  const observe = () => {
+    for (const node of [root.ownerDocument, root.getRootNode(), proxy.form]) {
+      if (!node || observed.has(node)) continue;
+      observed.set(node, on(node, "formdata", handleFormData, { capture: true }));
+    }
+  };
+  observe();
+
+  return {
+    observe,
+    destroy() {
+      for (const cleanup of observed.values()) cleanup();
+      observed.clear();
+      marker.remove();
+    },
+  };
+}

--- a/packages/core/src/form-field.test.ts
+++ b/packages/core/src/form-field.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createFormFieldAdapter, type FormFieldAdapter } from "./form-field";
+
+const adapters: FormFieldAdapter[] = [];
+const nextTask = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  for (const adapter of adapters) adapter.destroy();
+  adapters.length = 0;
+  document.body.innerHTML = "";
+});
+
+function setup({ detached = false, name = "fruit" as string | null, control = false } = {}) {
+  const container = document.createElement("div");
+  container.innerHTML = "<form></form><div></div>";
+  const form = container.querySelector("form")!;
+  const root = container.querySelector("div")!;
+  const input = control ? document.createElement("input") : null;
+  if (input) root.appendChild(input);
+  if (!detached) {
+    document.body.appendChild(form);
+    form.appendChild(root);
+  }
+  const resets: Array<string | null> = [];
+  const adapter = createFormFieldAdapter({
+    root,
+    name,
+    defaultValue: "banana",
+    control: input,
+    onReset: (value) => resets.push(value),
+  });
+  adapters.push(adapter);
+  adapter.setValue("apple");
+  return { form, root, input, adapter, resets };
+}
+
+// Happy DOM neither excludes disabled inputs nor dispatches `formdata`.
+// Supply the native event boundary here; fieldset inheritance is browser-tested.
+function collectFormData(form: HTMLFormElement) {
+  const formData = new FormData();
+  for (const input of form.querySelectorAll("input")) {
+    if (input.name && !input.disabled) formData.append(input.name, input.value);
+  }
+  const event = new Event("formdata", { bubbles: true });
+  Object.defineProperty(event, "formData", { value: formData });
+  form.dispatchEvent(event);
+  return formData;
+}
+
+describe("core/form-field", () => {
+  it("waits until after microtasks and native control resetting", async () => {
+    const { form, root, resets } = setup();
+    form.reset();
+    await Promise.resolve();
+    expect(resets).toEqual([]);
+    await nextTask();
+    expect(resets).toEqual(["banana"]);
+    expect(root.querySelector("input")?.value).toBe("banana");
+  });
+
+  it("observes later cancellation even when propagation stops at the form", async () => {
+    const { form, resets } = setup();
+    form.addEventListener("reset", (event) => {
+      event.stopPropagation();
+      event.preventDefault();
+    });
+    form.reset();
+    await nextTask();
+    expect(resets).toEqual([]);
+  });
+
+  it("receives uncanceled resets whose propagation stops at the form", async () => {
+    const { form, resets } = setup();
+    form.addEventListener("reset", (event) => event.stopPropagation());
+    form.reset();
+    await nextTask();
+    expect(resets).toEqual(["banana"]);
+  });
+
+  it("preserves a completed reset when the next reset is canceled", async () => {
+    const { form, root, resets } = setup();
+    form.reset();
+    form.addEventListener("reset", (event) => event.preventDefault(), { once: true });
+    form.reset();
+    await nextTask();
+    expect(resets).toEqual(["banana"]);
+    expect(root.querySelector("input")?.value).toBe("banana");
+  });
+
+  it("preserves a newer selection when a subsequent reset is canceled", async () => {
+    const { form, adapter, root, resets } = setup();
+    form.reset();
+    adapter.setValue("cherry");
+    form.addEventListener("reset", (event) => event.preventDefault(), { once: true });
+    form.reset();
+    await nextTask();
+    expect(resets).toEqual([]);
+    expect(root.querySelector("input")?.value).toBe("cherry");
+  });
+
+  it("applies a later uncanceled reset after a newer selection", async () => {
+    const { form, adapter, root, resets } = setup();
+    form.reset();
+    adapter.setValue("cherry");
+    form.reset();
+    await nextTask();
+    expect(resets).toEqual(["banana"]);
+    expect(root.querySelector("input")?.value).toBe("banana");
+  });
+
+  it("cleans up pending and future resets on destroy", async () => {
+    const { form, adapter, resets } = setup();
+    form.reset();
+    form.reset();
+    adapter.destroy();
+    await nextTask();
+    form.reset();
+    await nextTask();
+    expect(resets).toEqual([]);
+  });
+
+  it("preserves a value selected after the reset call", async () => {
+    const { form, adapter, root, resets } = setup();
+    form.reset();
+    adapter.setValue("cherry");
+    await nextTask();
+    expect(resets).toEqual([]);
+    expect(root.querySelector("input")?.value).toBe("cherry");
+  });
+
+  for (const name of ["fruit", null]) {
+    it(`resets a ${name ? "named" : "unnamed"} form detached after initialization`, async () => {
+      const { form, root, resets } = setup({ name });
+      form.remove();
+      form.reset();
+      await nextTask();
+      expect(resets).toEqual(["banana"]);
+      if (name) expect(root.querySelector("input")?.value).toBe("banana");
+    });
+
+    it(`resets a ${name ? "named" : "unnamed"} root mounted after initialization`, async () => {
+      const { form, root, resets } = setup({ detached: true, name });
+      document.body.appendChild(form);
+      form.appendChild(root);
+      form.reset();
+      await nextTask();
+      expect(resets).toEqual(["banana"]);
+    });
+
+    it(`follows a ${name ? "named" : "unnamed"} root moved between forms`, async () => {
+      const { form, root, resets } = setup({ name });
+      const nextForm = document.createElement("form");
+      document.body.appendChild(nextForm);
+      nextForm.appendChild(root);
+      form.reset();
+      await nextTask();
+      expect(resets).toEqual([]);
+      nextForm.reset();
+      await nextTask();
+      expect(resets).toEqual(["banana"]);
+    });
+  }
+
+  it("resets an initially detached form once before and after mounting", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = "<form><div></div></form>";
+    const form = container.querySelector("form")!;
+    const root = form.querySelector("div")!;
+    // Happy DOM returns detached nodes themselves instead of their tree root.
+    Object.defineProperty(root, "getRootNode", { value: () => container });
+    let resetCount = 0;
+    const adapter = createFormFieldAdapter({
+      root, name: "fruit", defaultValue: "banana", onReset: () => resetCount++,
+    });
+    adapters.push(adapter);
+    form.reset();
+    await nextTask();
+    expect(resetCount).toBe(1);
+    document.body.appendChild(form);
+    form.reset();
+    await nextTask();
+    expect(resetCount).toBe(2);
+  });
+
+  it("preserves a disabled authored input's submission and destroy semantics", () => {
+    document.body.innerHTML = '<form><div><input name="fruit" disabled></div></form>';
+    const form = document.querySelector("form")!;
+    const root = form.querySelector("div")!;
+    const control = root.querySelector("input")!;
+    const adapter = createFormFieldAdapter({
+      root, control, name: "fruit", defaultValue: "apple", onReset: () => {},
+    });
+    adapters.push(adapter);
+    const proxy = root.querySelector<HTMLInputElement>("[data-form-field-generated]")!;
+    expect(proxy.disabled).toBe(true);
+    // Browser coverage verifies FormData omission; Happy DOM includes disabled controls.
+    adapter.destroy();
+    expect(control.name).toBe("fruit");
+    expect(control.disabled).toBe(true);
+  });
+
+  it("uses the control's disabled state at submission, including same-task changes", () => {
+    const { form, input } = setup({ control: true });
+    expect(Array.from(collectFormData(form))).toEqual([["fruit", "apple"]]);
+    input!.disabled = true;
+    expect(Array.from(collectFormData(form))).toEqual([]);
+    input!.disabled = false;
+    expect(Array.from(collectFormData(form))).toEqual([["fruit", "apple"]]);
+  });
+
+  it("submits an initially disabled authored input after it is reenabled", () => {
+    document.body.innerHTML = '<form><div><input name="fruit" disabled></div></form>';
+    const form = document.querySelector("form")!;
+    const root = form.querySelector("div")!;
+    const control = root.querySelector("input")!;
+    const adapter = createFormFieldAdapter({
+      root, control, name: "fruit", defaultValue: "apple", onReset: () => {},
+    });
+    adapters.push(adapter);
+    control.disabled = false;
+    expect(Array.from(collectFormData(form))).toEqual([["fruit", "apple"]]);
+  });
+
+  it("preserves duplicate names, identical values, and entry order", () => {
+    const { form, root, input } = setup({ control: true });
+    root.insertAdjacentHTML("beforebegin", '<input name="fruit" value="apple"><input name="other" value="before">');
+    form.insertAdjacentHTML("beforeend", '<input name="other" value="after"><input name="fruit" value="apple">');
+    const surrounding: Array<[string, string]> = [["fruit", "apple"], ["other", "before"], ["other", "after"], ["fruit", "apple"]];
+    input!.disabled = true;
+    expect(Array.from(collectFormData(form))).toEqual(surrounding);
+    input!.disabled = false;
+    expect(Array.from(collectFormData(form))).toEqual([
+      ...surrounding.slice(0, 2), ["fruit", "apple"], ...surrounding.slice(2),
+    ]);
+  });
+
+  it("keeps an explicitly disabled composite excluded even if the input is enabled", () => {
+    document.body.innerHTML = '<form><div><input name="fruit"></div></form>';
+    const form = document.querySelector("form")!;
+    const root = form.querySelector("div")!;
+    const control = root.querySelector("input")!;
+    const adapter = createFormFieldAdapter({
+      root, control, name: "fruit", defaultValue: "apple", disabled: true, onReset: () => {},
+    });
+    adapters.push(adapter);
+    expect(Array.from(collectFormData(form))).toEqual([]);
+  });
+
+  it("removes submission bookkeeping and restores the native field on destroy", () => {
+    const { form, root, input, adapter } = setup({ control: true });
+    adapter.destroy();
+    expect(root.querySelectorAll("input").length).toBe(1);
+    input!.name = "fruit";
+    input!.value = "Authored text";
+    expect(Array.from(collectFormData(form))).toEqual([["fruit", "Authored text"]]);
+  });
+
+  it("keeps an unnamed composite associated while its input is portaled", async () => {
+    const { form, input, resets } = setup({ name: null, control: true });
+    document.body.appendChild(input!);
+    form.reset();
+    await nextTask();
+    expect(resets).toEqual(["banana"]);
+  });
+});

--- a/packages/core/src/form-field.ts
+++ b/packages/core/src/form-field.ts
@@ -1,3 +1,75 @@
+import { on } from "./events.ts";
+import { observeFormFieldSubmission } from "./form-field-submission.ts";
+
+/** Observes native form resets that target the composite control's form. */
+export interface FormResetObserver {
+  /**
+   * Re-checks the root's tree and starts observing it when new. Call after
+   * the root may have moved into a shadow tree, since `reset` is not composed.
+   */
+  observe(): void;
+  destroy(): void;
+}
+
+/**
+ * Listens for `reset` on the root's document, tree root, and owning form in the capture
+ * phase, so resets whose propagation stops at the form are still seen, and
+ * applies them on the next task, after all listeners (including late
+ * `preventDefault()` calls) and native control resetting have finished.
+ * Ownership is resolved at dispatch time via `getForm`, so a root initialized
+ * detached or moved between forms follows its current form. The direct form
+ * listener also survives detaching a previously observed form.
+ */
+export function observeFormReset({
+  root,
+  getForm,
+  onReset,
+  onResetDispatched,
+}: {
+  root: Element;
+  getForm: () => HTMLFormElement | null;
+  /** Runs on the next task after an uncanceled reset of the current form. */
+  onReset: (event: Event) => void;
+  /** Runs synchronously when a reset of the current form is first observed. */
+  onResetDispatched?: (event: Event) => void;
+}): FormResetObserver {
+  const observed = new Map<Node, () => void>();
+  const pending = new Map<Event, ReturnType<typeof setTimeout>>();
+
+  const handleReset = (event: Event) => {
+    if (event.target !== getForm() || pending.has(event)) return;
+    observe();
+    onResetDispatched?.(event);
+    // Browser-dispatched events can run microtasks between listeners. Wait for
+    // the next task so all cancellation and native control resetting finish.
+    const timeout = setTimeout(() => {
+      pending.delete(event);
+      if (event.defaultPrevented || event.target !== getForm()) return;
+      onReset(event);
+    }, 0);
+    // Keep earlier resets: a later dispatch may still be canceled.
+    pending.set(event, timeout);
+  };
+
+  const observe = () => {
+    for (const node of [root.ownerDocument, root.getRootNode(), getForm()]) {
+      if (!node || observed.has(node)) continue;
+      observed.set(node, on(node, "reset", handleReset, { capture: true }));
+    }
+  };
+  observe();
+
+  return {
+    observe,
+    destroy() {
+      for (const timeout of pending.values()) clearTimeout(timeout);
+      pending.clear();
+      for (const cleanup of observed.values()) cleanup();
+      observed.clear();
+    },
+  };
+}
+
 /** Native-form boundary for composite controls. */
 export interface FormFieldAdapter {
   setValue(value: string | null): void;
@@ -10,16 +82,17 @@ export function createFormFieldAdapter({
   name,
   defaultValue,
   control,
+  disabled = false,
   onReset,
 }: {
   root: Element;
   name: string | null;
   defaultValue: string | null;
   control?: HTMLInputElement | null;
+  /** Excludes the generated input from submission, like a disabled native control. */
+  disabled?: boolean;
   onReset: (value: string | null) => void;
 }): FormFieldAdapter {
-  let currentValue = defaultValue;
-  let destroyed = false;
   const authoredName = control?.getAttribute("name") ?? null;
   const authoredForm = control?.getAttribute("form") ?? null;
   let proxy: HTMLInputElement | null = null;
@@ -29,39 +102,61 @@ export function createFormFieldAdapter({
     proxy = root.ownerDocument.createElement("input");
     proxy.type = "hidden";
     proxy.name = name;
-    proxy.value = currentValue ?? "";
+    proxy.value = defaultValue ?? "";
     proxy.defaultValue = defaultValue ?? "";
+    proxy.disabled = disabled || (control?.disabled ?? false);
     if (authoredForm !== null) proxy.setAttribute("form", authoredForm);
     proxy.setAttribute("data-form-field-generated", "");
     root.appendChild(proxy);
   }
 
-  const form =
-    proxy?.form ??
-    control?.form ??
-    (root.closest("form") instanceof HTMLFormElement ? root.closest("form") : null);
-  const handleReset = (event: Event) => {
-    // Native controls reset after dispatch. Deferring also observes a later
-    // listener that cancels the reset.
-    queueMicrotask(() => {
-      if (destroyed || event.defaultPrevented) return;
-      currentValue = defaultValue;
-      if (proxy) proxy.value = defaultValue ?? "";
-      onReset(defaultValue);
-    });
+  const submission = control && proxy
+    ? observeFormFieldSubmission(root, control, proxy, disabled)
+    : null;
+
+  // A native control with an unresolved explicit `form` attribute deliberately
+  // has no owner.
+  const getForm = () => {
+    if (proxy) return proxy.form;
+    if (control?.hasAttribute("form")) return control.form;
+    if (control?.form) return control.form;
+    return root.closest("form");
   };
-  form?.addEventListener("reset", handleReset);
+
+  // A value chosen after the reset event was dispatched wins over the reset.
+  let lastValue = defaultValue;
+  let valueVersion = 0;
+  const resetVersions = new WeakMap<Event, number>();
+  const observer = observeFormReset({
+    root,
+    getForm,
+    onResetDispatched: (event) => {
+      resetVersions.set(event, valueVersion);
+    },
+    onReset: (event) => {
+      if (resetVersions.get(event) !== valueVersion) return;
+      if (proxy) proxy.value = defaultValue ?? "";
+      lastValue = defaultValue;
+      onReset(defaultValue);
+    },
+  });
 
   return {
     setValue(value) {
-      currentValue = value;
+      if (value !== lastValue) {
+        lastValue = value;
+        valueVersion++;
+      }
       if (proxy) proxy.value = value ?? "";
+      submission?.observe();
+      observer.observe();
     },
     destroy() {
-      destroyed = true;
-      form?.removeEventListener("reset", handleReset);
+      observer.destroy();
+      submission?.destroy();
       proxy?.remove();
-      if (control) {
+      // Only restore what was stripped above.
+      if (control && name) {
         if (authoredName === null) control.removeAttribute("name");
         else control.setAttribute("name", authoredName);
       }

--- a/packages/core/src/form-field.ts
+++ b/packages/core/src/form-field.ts
@@ -1,82 +1,70 @@
-/**
- * Owns the native-form boundary for composite controls. The generated hidden
- * input is the single successful control, while the visible control may keep
- * its own presentation state.
- */
-export class FormFieldAdapter {
-  readonly defaultValue: string;
-  private currentValue: string;
-  private readonly proxy: HTMLInputElement | null;
-  private readonly control: HTMLInputElement | null;
-  private readonly authoredName: string | null;
-  private destroyed = false;
-  private readonly removeResetListener: (() => void) | null;
+/** Native-form boundary for composite controls. */
+export interface FormFieldAdapter {
+  setValue(value: string | null): void;
+  destroy(): void;
+}
 
-  constructor({
-    root,
-    name,
-    defaultValue,
-    control,
-    onReset,
-  }: {
-    root: Element;
-    name: string | null;
-    defaultValue: string | null;
-    control?: HTMLInputElement | null;
-    onReset: (value: string | null) => void;
-  }) {
-    this.defaultValue = defaultValue ?? "";
-    this.currentValue = this.defaultValue;
-    this.control = control ?? null;
-    this.authoredName = this.control?.getAttribute("name") ?? null;
+/** Keeps a composite control synchronized with a native form. */
+export function createFormFieldAdapter({
+  root,
+  name,
+  defaultValue,
+  control,
+  onReset,
+}: {
+  root: Element;
+  name: string | null;
+  defaultValue: string | null;
+  control?: HTMLInputElement | null;
+  onReset: (value: string | null) => void;
+}): FormFieldAdapter {
+  let currentValue = defaultValue;
+  let destroyed = false;
+  const authoredName = control?.getAttribute("name") ?? null;
+  const authoredForm = control?.getAttribute("form") ?? null;
+  let proxy: HTMLInputElement | null = null;
 
-    if (!name) {
-      this.proxy = null;
-      this.removeResetListener = null;
-      return;
-    }
-
-    if (this.control) this.control.removeAttribute("name");
-    const proxy = root.ownerDocument.createElement("input");
+  if (name) {
+    control?.removeAttribute("name");
+    proxy = root.ownerDocument.createElement("input");
     proxy.type = "hidden";
     proxy.name = name;
-    proxy.value = this.currentValue;
-    proxy.defaultValue = this.defaultValue;
+    proxy.value = currentValue ?? "";
+    proxy.defaultValue = defaultValue ?? "";
+    if (authoredForm !== null) proxy.setAttribute("form", authoredForm);
     proxy.setAttribute("data-form-field-generated", "");
     root.appendChild(proxy);
-    this.proxy = proxy;
-
-    const form = proxy.form ?? (root.closest("form") instanceof HTMLFormElement ? root.closest("form") : null);
-    if (!form) {
-      this.removeResetListener = null;
-      return;
-    }
-    const handleReset = (event: Event) => {
-      // The browser resets controls after dispatching reset. A microtask also
-      // lets later listeners cancel the event before presentation is synced.
-      queueMicrotask(() => {
-        if (this.destroyed || event.defaultPrevented) return;
-        this.currentValue = this.defaultValue;
-        if (this.proxy) this.proxy.value = this.defaultValue;
-        onReset(this.defaultValue === "" ? null : this.defaultValue);
-      });
-    };
-    form.addEventListener("reset", handleReset);
-    this.removeResetListener = () => form.removeEventListener("reset", handleReset);
   }
 
-  setValue(value: string | null): void {
-    this.currentValue = value ?? "";
-    if (this.proxy) this.proxy.value = this.currentValue;
-  }
+  const form =
+    proxy?.form ??
+    control?.form ??
+    (root.closest("form") instanceof HTMLFormElement ? root.closest("form") : null);
+  const handleReset = (event: Event) => {
+    // Native controls reset after dispatch. Deferring also observes a later
+    // listener that cancels the reset.
+    queueMicrotask(() => {
+      if (destroyed || event.defaultPrevented) return;
+      currentValue = defaultValue;
+      if (proxy) proxy.value = defaultValue ?? "";
+      onReset(defaultValue);
+    });
+  };
+  form?.addEventListener("reset", handleReset);
 
-  destroy(): void {
-    this.destroyed = true;
-    this.removeResetListener?.();
-    this.proxy?.remove();
-    if (this.control) {
-      if (this.authoredName === null) this.control.removeAttribute("name");
-      else this.control.setAttribute("name", this.authoredName);
-    }
-  }
+  return {
+    setValue(value) {
+      currentValue = value;
+      if (proxy) proxy.value = value ?? "";
+    },
+    destroy() {
+      destroyed = true;
+      form?.removeEventListener("reset", handleReset);
+      proxy?.remove();
+      if (control) {
+        if (authoredName === null) control.removeAttribute("name");
+        else control.setAttribute("name", authoredName);
+      }
+    },
+  };
 }

--- a/packages/core/src/form-field.ts
+++ b/packages/core/src/form-field.ts
@@ -1,0 +1,82 @@
+/**
+ * Owns the native-form boundary for composite controls. The generated hidden
+ * input is the single successful control, while the visible control may keep
+ * its own presentation state.
+ */
+export class FormFieldAdapter {
+  readonly defaultValue: string;
+  private currentValue: string;
+  private readonly proxy: HTMLInputElement | null;
+  private readonly control: HTMLInputElement | null;
+  private readonly authoredName: string | null;
+  private destroyed = false;
+  private readonly removeResetListener: (() => void) | null;
+
+  constructor({
+    root,
+    name,
+    defaultValue,
+    control,
+    onReset,
+  }: {
+    root: Element;
+    name: string | null;
+    defaultValue: string | null;
+    control?: HTMLInputElement | null;
+    onReset: (value: string | null) => void;
+  }) {
+    this.defaultValue = defaultValue ?? "";
+    this.currentValue = this.defaultValue;
+    this.control = control ?? null;
+    this.authoredName = this.control?.getAttribute("name") ?? null;
+
+    if (!name) {
+      this.proxy = null;
+      this.removeResetListener = null;
+      return;
+    }
+
+    if (this.control) this.control.removeAttribute("name");
+    const proxy = root.ownerDocument.createElement("input");
+    proxy.type = "hidden";
+    proxy.name = name;
+    proxy.value = this.currentValue;
+    proxy.defaultValue = this.defaultValue;
+    proxy.setAttribute("data-form-field-generated", "");
+    root.appendChild(proxy);
+    this.proxy = proxy;
+
+    const form = proxy.form ?? (root.closest("form") instanceof HTMLFormElement ? root.closest("form") : null);
+    if (!form) {
+      this.removeResetListener = null;
+      return;
+    }
+    const handleReset = (event: Event) => {
+      // The browser resets controls after dispatching reset. A microtask also
+      // lets later listeners cancel the event before presentation is synced.
+      queueMicrotask(() => {
+        if (this.destroyed || event.defaultPrevented) return;
+        this.currentValue = this.defaultValue;
+        if (this.proxy) this.proxy.value = this.defaultValue;
+        onReset(this.defaultValue === "" ? null : this.defaultValue);
+      });
+    };
+    form.addEventListener("reset", handleReset);
+    this.removeResetListener = () => form.removeEventListener("reset", handleReset);
+  }
+
+  setValue(value: string | null): void {
+    this.currentValue = value ?? "";
+    if (this.proxy) this.proxy.value = this.currentValue;
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.removeResetListener?.();
+    this.proxy?.remove();
+    if (this.control) {
+      if (this.authoredName === null) this.control.removeAttribute("name");
+      else this.control.setAttribute("name", this.authoredName);
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,8 +19,8 @@ export {
 export type { PortalState } from "./parts.ts";
 export { ensureId, setAria, linkLabelledBy } from "./aria.ts";
 export { on, emit, composeHandlers } from "./events.ts";
-export { createFormFieldAdapter } from "./form-field.ts";
-export type { FormFieldAdapter } from "./form-field.ts";
+export { createFormFieldAdapter, observeFormReset } from "./form-field.ts";
+export type { FormFieldAdapter, FormResetObserver } from "./form-field.ts";
 export { lockScroll, unlockScroll } from "./scroll.ts";
 export {
   computeFloatingPosition,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,8 @@ export {
 export type { PortalState } from "./parts.ts";
 export { ensureId, setAria, linkLabelledBy } from "./aria.ts";
 export { on, emit, composeHandlers } from "./events.ts";
-export { FormFieldAdapter } from "./form-field.ts";
+export { createFormFieldAdapter } from "./form-field.ts";
+export type { FormFieldAdapter } from "./form-field.ts";
 export { lockScroll, unlockScroll } from "./scroll.ts";
 export {
   computeFloatingPosition,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export {
 export type { PortalState } from "./parts.ts";
 export { ensureId, setAria, linkLabelledBy } from "./aria.ts";
 export { on, emit, composeHandlers } from "./events.ts";
+export { FormFieldAdapter } from "./form-field.ts";
 export { lockScroll, unlockScroll } from "./scroll.ts";
 export {
   computeFloatingPosition,

--- a/packages/radio-group/src/index.test.ts
+++ b/packages/radio-group/src/index.test.ts
@@ -261,7 +261,7 @@ describe("RadioGroup", () => {
       expect(radioItems[0]?.hasAttribute("data-required")).toBe(true);
     });
 
-    it("restores the default selection on native form reset", async () => {
+    it.each(["connected", "detached", "canceled second reset"])("restores the default selection on native form reset (%s)", async (scenario) => {
       document.body.innerHTML = `
         <form id="form">
           <div
@@ -285,15 +285,23 @@ describe("RadioGroup", () => {
       const form = document.getElementById("form") as HTMLFormElement;
       const root = document.getElementById("root") as HTMLElement;
       const controller = createRadioGroup(root);
+      const inputs = getHiddenInputs();
 
       controller.select("pro");
       expect(controller.value).toBe("pro");
 
+      if (scenario === "detached") form.remove();
       form.reset();
-      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      if (scenario === "canceled second reset") {
+        form.addEventListener("reset", (event) => event.preventDefault(), { once: true });
+        form.reset();
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
       expect(controller.value).toBe("starter");
-      expect(getHiddenInputs()[0]?.checked).toBe(true);
+      expect(inputs[0]?.checked).toBe(true);
+      expect(root.querySelector('[data-value="starter"]')?.getAttribute("aria-checked")).toBe("true");
+      controller.destroy();
     });
   });
 

--- a/packages/radio-group/src/index.ts
+++ b/packages/radio-group/src/index.ts
@@ -11,6 +11,7 @@ import {
   ensureId,
   on,
   emit,
+  observeFormReset,
 } from "@data-slot/core";
 
 export interface RadioGroupOptions {
@@ -499,23 +500,18 @@ export function createRadioGroup(
   syncRoot();
   syncItems();
 
-  const form =
-    items.find((item) => item.hiddenInput.form)?.hiddenInput.form ??
-    (rootElement.closest("form") instanceof HTMLFormElement
-      ? rootElement.closest("form")
-      : null);
-
-  if (form) {
-    cleanups.push(
-      on(form, "reset", () => {
-        queueMicrotask(() => {
-          const checkedItem =
-            items.find((candidate) => candidate.hiddenInput.checked) ?? null;
-          applyState(checkedItem, false);
-        });
-      }),
-    );
-  }
+  const resetObserver = observeFormReset({
+    root: rootElement,
+    getForm: () =>
+      items.find((item) => item.hiddenInput.form)?.hiddenInput.form ??
+      rootElement.closest("form"),
+    onReset: () => {
+      const checkedItem =
+        items.find((candidate) => candidate.hiddenInput.checked) ?? null;
+      applyState(checkedItem, false);
+    },
+  });
+  cleanups.push(() => resetObserver.destroy());
 
   cleanups.push(
     on(rootElement, "radio-group:set", (event) => {

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -264,6 +264,13 @@ When `name` is provided, a hidden input is automatically created for form submis
 </form>
 ```
 
+A disabled select does not submit its value.
+
+Resetting the form restores `defaultValue` and its displayed selection without
+emitting a value-change event, including when the select has no `name`.
+Synchronization happens on the next event-loop task, after the browser resets
+native controls. Calling `preventDefault()` on the reset event preserves the current state.
+
 ## License
 
 MIT

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -1247,7 +1247,7 @@ describe("Select", () => {
 
       controller.select("apple");
       form.reset();
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(controller.value).toBe("banana");
       expect(root.querySelector('[data-slot="select-value"]')?.textContent).toBe("Banana");
@@ -1265,7 +1265,7 @@ describe("Select", () => {
       controller.select("apple");
       form.addEventListener("reset", (event) => event.preventDefault());
       form.reset();
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(controller.value).toBe("apple");
       controller.destroy();
     });
@@ -1277,10 +1277,87 @@ describe("Select", () => {
       const controller = createSelect(root, { defaultValue: "" });
       controller.select("apple");
       form.reset();
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(controller.value).toBe("");
       expect(root.querySelector('input[type="hidden"]')).toBeNull();
       controller.destroy();
+    });
+
+    for (const name of ["fruit", undefined]) {
+      const fieldType = name ? "named" : "unnamed";
+
+      it(`resets an initially detached ${fieldType} select after attaching it to a form`, async () => {
+        const root = document.createElement("div");
+        root.innerHTML = `
+          <button data-slot="select-trigger"><span data-slot="select-value"></span></button>
+          <div data-slot="select-content"><div data-slot="select-item" data-value="apple">Apple</div><div data-slot="select-item" data-value="banana">Banana</div></div>`;
+        const controller = createSelect(root, { name, defaultValue: "banana" });
+        const form = document.createElement("form");
+        document.body.appendChild(form);
+        form.appendChild(root);
+        controller.select("apple");
+
+        form.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(controller.value).toBe("banana");
+        expect(root.querySelector('[data-slot="select-value"]')?.textContent).toBe("Banana");
+        expect(new FormData(form).get("fruit")).toBe(name ? "banana" : null);
+        controller.destroy();
+      });
+
+      it(`follows the current form when the ${fieldType} select moves between forms`, async () => {
+        const { root, controller } = setup({ name, defaultValue: "banana" });
+        const firstForm = document.createElement("form");
+        const secondForm = document.createElement("form");
+        const unrelatedForm = document.createElement("form");
+        document.body.append(firstForm, secondForm, unrelatedForm);
+        firstForm.appendChild(root);
+        controller.select("apple");
+
+        firstForm.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(controller.value).toBe("banana");
+
+        secondForm.appendChild(root);
+        controller.select("apple");
+        firstForm.reset();
+        unrelatedForm.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(controller.value).toBe("apple");
+
+        secondForm.reset();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(controller.value).toBe("banana");
+        expect(new FormData(firstForm).get("fruit")).toBeNull();
+        expect(new FormData(secondForm).get("fruit")).toBe(name ? "banana" : null);
+        controller.destroy();
+      });
+    }
+
+    it("does not let a queued reset overwrite a rebound select", async () => {
+      const { root, controller } = setup({ name: "fruit", defaultValue: "banana" }, `
+        <form><div data-slot="select" id="root">
+          <button data-slot="select-trigger"><span data-slot="select-value"></span></button>
+          <div data-slot="select-content"><div data-slot="select-item" data-value="apple">Apple</div><div data-slot="select-item" data-value="banana">Banana</div></div>
+        </div></form>`);
+      const form = root.closest("form")!;
+      controller.select("apple");
+
+      form.reset();
+      controller.destroy();
+      const rebound = createSelect(root, { name: "fruit", defaultValue: "apple" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(controller.value).toBe("apple");
+      expect(rebound.value).toBe("apple");
+      expect(root.querySelector('[data-slot="select-value"]')?.textContent).toBe("Apple");
+      expect(new FormData(form).getAll("fruit")).toEqual(["apple"]);
+      rebound.select("banana");
+      form.reset();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(rebound.value).toBe("apple");
+      rebound.destroy();
     });
 
     it("reads data-name attribute", () => {

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -1234,6 +1234,42 @@ describe("Select", () => {
       expect(root.querySelector('input[type="hidden"]')).toBeFalsy();
     });
 
+    it("restores its initial value and form data after a native form reset without emitting change", async () => {
+      document.body.innerHTML = `
+        <form><div data-slot="select" id="root">
+          <button data-slot="select-trigger"><span data-slot="select-value"></span></button>
+          <div data-slot="select-content"><div data-slot="select-item" data-value="apple">Apple</div><div data-slot="select-item" data-value="banana">Banana</div></div>
+        </div></form>`;
+      const root = document.getElementById("root")!;
+      const form = root.closest("form")!;
+      let changes = 0;
+      const controller = createSelect(root, { name: "fruit", defaultValue: "banana", onValueChange: () => changes++ });
+
+      controller.select("apple");
+      form.reset();
+      await Promise.resolve();
+
+      expect(controller.value).toBe("banana");
+      expect(root.querySelector('[data-slot="select-value"]')?.textContent).toBe("Banana");
+      expect(root.querySelector('[data-value="banana"]')?.getAttribute("aria-selected")).toBe("true");
+      expect(new FormData(form).get("fruit")).toBe("banana");
+      expect(changes).toBe(1);
+      controller.destroy();
+    });
+
+    it("does not apply a canceled form reset", async () => {
+      document.body.innerHTML = `<form><div data-slot="select" id="root"><button data-slot="select-trigger"><span data-slot="select-value"></span></button><div data-slot="select-content"><div data-slot="select-item" data-value="apple">Apple</div><div data-slot="select-item" data-value="banana">Banana</div></div></div></form>`;
+      const root = document.getElementById("root")!;
+      const form = root.closest("form")!;
+      const controller = createSelect(root, { name: "fruit", defaultValue: "banana" });
+      controller.select("apple");
+      form.addEventListener("reset", (event) => event.preventDefault());
+      form.reset();
+      await Promise.resolve();
+      expect(controller.value).toBe("apple");
+      controller.destroy();
+    });
+
     it("reads data-name attribute", () => {
       document.body.innerHTML = `
         <div data-slot="select" id="root" data-name="fruit">

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -1270,6 +1270,19 @@ describe("Select", () => {
       controller.destroy();
     });
 
+    it("resets an unnamed select with an empty-string default without serializing a proxy", async () => {
+      document.body.innerHTML = `<form><div data-slot="select" id="root"><button data-slot="select-trigger"><span data-slot="select-value"></span></button><div data-slot="select-content"><div data-slot="select-item" data-value="">Empty</div><div data-slot="select-item" data-value="apple">Apple</div></div></div></form>`;
+      const root = document.getElementById("root")!;
+      const form = root.closest("form")!;
+      const controller = createSelect(root, { defaultValue: "" });
+      controller.select("apple");
+      form.reset();
+      await Promise.resolve();
+      expect(controller.value).toBe("");
+      expect(root.querySelector('input[type="hidden"]')).toBeNull();
+      controller.destroy();
+    });
+
     it("reads data-name attribute", () => {
       document.body.innerHTML = `
         <div data-slot="select" id="root" data-name="fruit">

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -252,6 +252,14 @@ export function createSelect(
     for (const el of items) el.removeAttribute("data-highlighted");
     highlightedIndex = -1;
   };
+  const highlightSelectedItem = () => {
+    const selectedIndex = enabledItems.findIndex((el) => el.dataset["value"] === currentValue);
+    if (selectedIndex >= 0) {
+      updateHighlight(selectedIndex, false, false);
+    } else {
+      clearHighlight();
+    }
+  };
   const clearHighlightAndFocusContent = () => {
     clearHighlight();
     focusElement(content);
@@ -348,14 +356,7 @@ export function createSelect(
 
       cacheItems();
       keyboardMode = false;
-
-      // Highlight selected item if any
-      const selectedIndex = enabledItems.findIndex((el) => el.dataset["value"] === currentValue);
-      if (selectedIndex >= 0) {
-        updateHighlight(selectedIndex, false, false);
-      } else {
-        clearHighlight();
-      }
+      highlightSelectedItem();
 
       positioning.start();
       positioning.update();
@@ -555,7 +556,14 @@ export function createSelect(
     root,
     name,
     defaultValue,
-    onReset: (value) => updateValue(value, true),
+    disabled,
+    onReset: (value) => {
+      updateValue(value, true);
+      if (isOpen) {
+        typeahead.reset();
+        highlightSelectedItem();
+      }
+    },
   });
 
   // Trigger events

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -8,7 +8,8 @@ import {
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
-import { FormFieldAdapter } from "@data-slot/core";
+import { createFormFieldAdapter } from "@data-slot/core";
+import type { FormFieldAdapter } from "@data-slot/core";
 import { lockScroll, unlockScroll } from "@data-slot/core";
 import {
   ensureItemVisibleInContainer,
@@ -550,7 +551,7 @@ export function createSelect(
   cacheItems();
   updateValue(currentValue, true);
 
-  formField = new FormFieldAdapter({
+  formField = createFormFieldAdapter({
     root,
     name,
     defaultValue,

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
+import { FormFieldAdapter } from "@data-slot/core";
 import { lockScroll, unlockScroll } from "@data-slot/core";
 import {
   ensureItemVisibleInContainer,
@@ -96,8 +97,7 @@ export function createSelect(
   let enabledItems: HTMLElement[] = [];
   let itemToIndex = new Map<HTMLElement, number>();
 
-  // Hidden input for form integration
-  let hiddenInput: HTMLInputElement | null = null;
+  let formField: FormFieldAdapter | null = null;
 
   // Track if this instance locked scroll
   let didLockScroll = false;
@@ -153,14 +153,6 @@ export function createSelect(
     trigger.setAttribute("aria-required", "true");
   }
 
-  // Create hidden input for form integration
-  if (name) {
-    hiddenInput = document.createElement("input");
-    hiddenInput.type = "hidden";
-    hiddenInput.name = name;
-    hiddenInput.value = currentValue ?? "";
-    root.appendChild(hiddenInput);
-  }
 
   // Cache items on open
   const cacheItems = () => {
@@ -432,10 +424,7 @@ export function createSelect(
     const oldValue = currentValue;
     currentValue = value;
 
-    // Update hidden input
-    if (hiddenInput) {
-      hiddenInput.value = value ?? "";
-    }
+    formField?.setValue(value);
 
     // Update root data-value
     if (value !== null) {
@@ -561,6 +550,13 @@ export function createSelect(
   cacheItems();
   updateValue(currentValue, true);
 
+  formField = new FormFieldAdapter({
+    root,
+    name,
+    defaultValue,
+    onReset: (value) => updateValue(value, true),
+  });
+
   // Trigger events
   cleanups.push(
     on(trigger, "pointerdown", (e) => {
@@ -650,9 +646,7 @@ export function createSelect(
       }
       cleanups.forEach((fn) => fn());
       cleanups.length = 0;
-      if (hiddenInput && hiddenInput.parentNode) {
-        hiddenInput.parentNode.removeChild(hiddenInput);
-      }
+      formField?.destroy();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };

--- a/packages/switch/src/index.test.ts
+++ b/packages/switch/src/index.test.ts
@@ -254,7 +254,7 @@ describe("Switch", () => {
       expect(hidden?.required).toBe(true);
     });
 
-    it("restores a checked-by-default switch on native form reset", async () => {
+    it.each(["connected", "detached", "canceled second reset"])("restores a checked-by-default switch on native form reset (%s)", async (scenario) => {
       document.body.innerHTML = `
         <form id="form">
           <label>
@@ -269,17 +269,24 @@ describe("Switch", () => {
       const form = document.getElementById("form") as HTMLFormElement;
       const root = document.getElementById("root") as HTMLElement;
       const controller = createSwitch(root);
+      const hidden = getHiddenCheckbox();
 
       controller.uncheck();
       expect(controller.checked).toBe(false);
 
+      if (scenario === "detached") form.remove();
       form.reset();
-      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      if (scenario === "canceled second reset") {
+        form.addEventListener("reset", (event) => event.preventDefault(), { once: true });
+        form.reset();
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
       expect(controller.checked).toBe(true);
       expect(root.getAttribute("aria-checked")).toBe("true");
       expect(root.hasAttribute("data-checked")).toBe(true);
-      expect(getHiddenCheckbox()?.checked).toBe(true);
+      expect(hidden?.checked).toBe(true);
+      controller.destroy();
     });
 
     it("restores an unchecked-by-default switch on native form reset", async () => {
@@ -308,7 +315,7 @@ describe("Switch", () => {
       expect(getHiddenUncheckedInput()).toBeNull();
 
       form.reset();
-      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
       expect(controller.checked).toBe(false);
       expect(root.getAttribute("aria-checked")).toBe("false");

--- a/packages/switch/src/index.ts
+++ b/packages/switch/src/index.ts
@@ -11,6 +11,7 @@ import {
   ensureId,
   on,
   emit,
+  observeFormReset,
 } from "@data-slot/core";
 
 export interface SwitchOptions {
@@ -309,20 +310,12 @@ export function createSwitch(
   syncGeneratedInputs();
   syncRoot();
 
-  const form =
-    hiddenInput.form ??
-    (rootElement.closest("form") instanceof HTMLFormElement
-      ? rootElement.closest("form")
-      : null);
-  if (form) {
-    cleanups.push(
-      on(form, "reset", () => {
-        queueMicrotask(() => {
-          updateState(hiddenInput.checked, false);
-        });
-      }),
-    );
-  }
+  const resetObserver = observeFormReset({
+    root: rootElement,
+    getForm: () => hiddenInput.form ?? rootElement.closest("form"),
+    onReset: () => updateState(hiddenInput.checked, false),
+  });
+  cleanups.push(() => resetObserver.destroy());
 
   cleanups.push(
     on(hiddenInput, "click", (event) => {


### PR DESCRIPTION
Native form resets previously left select and combobox state out of sync, and authored combobox input names could lose native disabled submission behavior when their value moved to a hidden input. This change restores initial selections on uncanceled resets and evaluates disabled submission eligibility when form data is constructed.

- Share form-reset observation across select, combobox, switch, and radio group, with deferred synchronization, cancellation handling, current form ownership, and cleanup of pending resets on destroy.
- Restore displayed selections and open-popup search/highlight state without emitting additional value-change events. Preserve selections made after a reset was dispatched.
- Preserve authored combobox names on destroy and external form associations. Respect same-task disabled changes and nested disabled fieldsets while keeping duplicate form entries in order.
- Document the authored-name behavior change: combobox inputs now submit the selected value rather than displayed or typed text.

Validation:
- `bun test`: 1,306 passing tests.
- Native browser comparison: 44 checks passing, including the three disabled-submission regressions, duplicate entries, fieldset legend exemption, multiple adapters, and external/detached forms.
- `bun run build`: passes.
- `bun run typecheck`: 143 existing diagnostics, matching `main` after normalizing shifted line numbers; no new diagnostics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/data-slot/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791627299&installation_model_id=433409&pr_number=14&repository=bejamas%2Fdata-slot&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fdata-slot%2Fpull%2F14&signature=9d7f68f6a72ec98ed2f2d3ef83c6a999598c4d61f60cfe909cf0f288311eb1e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->