### PR TITLE
Fix/select required validation

### DIFF
--- a/packages/core/src/form-field-submission.ts
+++ b/packages/core/src/form-field-submission.ts
@@ -4,7 +4,7 @@ import { on } from "./events.ts";
 export function observeFormFieldSubmission(
   root: Element,
   control: HTMLInputElement,
-  proxy: HTMLInputElement,
+  proxy: HTMLInputElement | HTMLSelectElement,
   disabled: boolean,
 ) {
   // The marker identifies this proxy's position without confusing it with other

--- a/packages/core/src/form-field-validation.ts
+++ b/packages/core/src/form-field-validation.ts
@@ -1,8 +1,7 @@
 import { on } from "./events.ts";
 
 /** Makes a visually hidden proxy validate and report errors at its visible control. */
-export function observeFormFieldValidation(proxy: HTMLInputElement, target?: HTMLElement) {
-  proxy.type = "text";
+export function observeFormFieldValidation(proxy: HTMLSelectElement, target?: HTMLElement) {
   proxy.required = true;
   proxy.tabIndex = -1;
   proxy.setAttribute("aria-hidden", "true");

--- a/packages/core/src/form-field.ts
+++ b/packages/core/src/form-field.ts
@@ -92,9 +92,9 @@ export function createFormFieldAdapter({
   name: string | null;
   defaultValue: string | null;
   control?: HTMLInputElement | null;
-  /** Excludes the generated input from submission, like a disabled native control. */
+  /** Excludes the generated control from submission, like a disabled native control. */
   disabled?: boolean;
-  /** Enables native required validation on the generated input. */
+  /** Enables native required validation on the generated control. */
   required?: boolean;
   /** Visible control that receives validation state and focus. */
   validationTarget?: HTMLElement;
@@ -102,23 +102,41 @@ export function createFormFieldAdapter({
 }): FormFieldAdapter {
   const authoredName = control?.getAttribute("name") ?? null;
   const authoredForm = control?.getAttribute("form") ?? null;
-  let proxy: HTMLInputElement | null = null;
+  let proxy: HTMLInputElement | HTMLSelectElement | null = null;
+  let validationProxy: HTMLSelectElement | null = null;
+  let selectedOption: HTMLOptionElement | null = null;
+  const setProxyValue = (value: string | null) => {
+    if (selectedOption) selectedOption.value = value ?? "";
+    if (proxy) proxy.value = value ?? "";
+  };
 
   if (name) {
     control?.removeAttribute("name");
-    proxy = root.ownerDocument.createElement("input");
-    proxy.type = "hidden";
+    if (required) {
+      // Unlike a text input, an option preserves CR/LF in arbitrary item values.
+      // One selected option also keeps empty values in FormData when validation
+      // is bypassed, without introducing a second submitted control.
+      validationProxy = root.ownerDocument.createElement("select");
+      selectedOption = root.ownerDocument.createElement("option");
+      selectedOption.defaultSelected = true;
+      validationProxy.appendChild(selectedOption);
+      proxy = validationProxy;
+    } else {
+      const input = root.ownerDocument.createElement("input");
+      input.type = "hidden";
+      input.defaultValue = defaultValue ?? "";
+      proxy = input;
+    }
     proxy.name = name;
-    proxy.value = defaultValue ?? "";
-    proxy.defaultValue = defaultValue ?? "";
+    setProxyValue(defaultValue);
     proxy.disabled = disabled || (control?.disabled ?? false);
     if (authoredForm !== null) proxy.setAttribute("form", authoredForm);
     proxy.setAttribute("data-form-field-generated", "");
     root.appendChild(proxy);
   }
 
-  const validation = required && proxy
-    ? observeFormFieldValidation(proxy, validationTarget)
+  const validation = validationProxy
+    ? observeFormFieldValidation(validationProxy, validationTarget)
     : null;
   const submission = control && proxy
     ? observeFormFieldSubmission(root, control, proxy, disabled)
@@ -145,13 +163,12 @@ export function createFormFieldAdapter({
     },
     onReset: (event) => {
       if (resetVersions.get(event) !== valueVersion) {
-        // A text proxy is reset natively after reset listeners run. Restore a
-        // selection made in a listener even when the deferred reset is skipped.
-        if (proxy) proxy.value = lastValue ?? "";
+        // Preserve a newer selection when the deferred reset is skipped.
+        setProxyValue(lastValue);
         validation?.sync();
         return;
       }
-      if (proxy) proxy.value = defaultValue ?? "";
+      setProxyValue(defaultValue);
       validation?.sync();
       lastValue = defaultValue;
       onReset(defaultValue);
@@ -164,7 +181,7 @@ export function createFormFieldAdapter({
         lastValue = value;
         valueVersion++;
       }
-      if (proxy) proxy.value = value ?? "";
+      setProxyValue(value);
       validation?.sync();
       submission?.observe();
       observer.observe();

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -135,7 +135,7 @@ Placement attributes (`position`, `side`, `align`, `sideOffset`, `alignOffset`, 
 | `placeholder` | `data-placeholder` | `string` | `""` | Text when no value selected |
 | `disabled` | `data-disabled` | `boolean` | `false` | Disable interaction |
 | `required` | `data-required` | `boolean` | `false` | Form validation required |
-| `name` | `data-name` | `string` | - | Form field name (creates hidden input) |
+| `name` | `data-name` | `string` | - | Form field name (creates an internal form input) |
 | `position` | `data-position` | `"item-aligned" \| "popper"` | `"item-aligned"` | Positioning mode (see below) |
 | `avoidCollisions` | `data-avoid-collisions` | `boolean` | `true` | Adjust to stay in viewport |
 | `collisionPadding` | `data-collision-padding` | `number` | `8` | Viewport edge padding (px) |
@@ -253,7 +253,7 @@ The component sets these attributes to reflect state:
 
 ## Form Integration
 
-When `name` is provided, a hidden input is automatically created for form submission:
+When `name` is provided, an internal input is automatically created for form submission and kept out of the visual and keyboard flow:
 
 ```html
 <form>
@@ -263,6 +263,8 @@ When `name` is provided, a hidden input is automatically created for form submis
   <button type="submit">Submit</button>
 </form>
 ```
+
+With `required` / `data-required`, this input participates in native validation. An empty required select blocks form submission and focuses the visible trigger. Disabled selects are excluded from validation and submission.
 
 ## License
 

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -135,7 +135,7 @@ Placement attributes (`position`, `side`, `align`, `sideOffset`, `alignOffset`, 
 | `placeholder` | `data-placeholder` | `string` | `""` | Text when no value selected |
 | `disabled` | `data-disabled` | `boolean` | `false` | Disable interaction |
 | `required` | `data-required` | `boolean` | `false` | Form validation required |
-| `name` | `data-name` | `string` | - | Form field name (creates an internal form input) |
+| `name` | `data-name` | `string` | - | Form field name (creates an internal form control) |
 | `position` | `data-position` | `"item-aligned" \| "popper"` | `"item-aligned"` | Positioning mode (see below) |
 | `avoidCollisions` | `data-avoid-collisions` | `boolean` | `true` | Adjust to stay in viewport |
 | `collisionPadding` | `data-collision-padding` | `number` | `8` | Viewport edge padding (px) |
@@ -253,7 +253,7 @@ The component sets these attributes to reflect state:
 
 ## Form Integration
 
-When `name` is provided, an internal input is automatically created for form submission and kept out of the visual and keyboard flow:
+When `name` is provided, an internal control is automatically created for form submission and kept out of the visual and keyboard flow:
 
 ```html
 <form>
@@ -264,7 +264,7 @@ When `name` is provided, an internal input is automatically created for form sub
 </form>
 ```
 
-With `required` / `data-required`, this input participates in native validation. An empty required select blocks form submission and focuses the visible trigger. Disabled selects are excluded from validation and submission.
+With `required` / `data-required`, this control participates in native validation. An empty required select blocks form submission and focuses the visible trigger. Disabled selects are excluded from validation and submission. Selected values are preserved exactly, including line breaks.
 
 Resetting the form restores `defaultValue` and its displayed selection without
 emitting a value-change event, including when the select has no `name`.

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -1202,6 +1202,39 @@ describe("Select", () => {
   });
 
   describe("form integration", () => {
+    it("participates in native required validation without adding a tab stop", () => {
+      document.body.innerHTML = `
+        <form><div data-slot="select" data-name="fruit" data-required>
+          <button data-slot="select-trigger"><span data-slot="select-value"></span></button>
+          <div data-slot="select-content"><div data-slot="select-item" data-value="apple">Apple</div></div>
+        </div></form>
+      `;
+      const root = document.querySelector('[data-slot="select"]') as HTMLElement;
+      const form = document.querySelector("form")!;
+      const trigger = document.querySelector('[data-slot="select-trigger"]') as HTMLElement;
+      const controller = createSelect(root);
+
+      expect(form.checkValidity()).toBe(false);
+      const field = form.elements.namedItem("fruit") as HTMLInputElement;
+      expect(field.validity.valueMissing).toBe(true);
+      expect(field.tabIndex).toBe(-1);
+      expect(document.activeElement).toBe(trigger);
+
+      controller.select("apple");
+      expect(form.checkValidity()).toBe(true);
+      expect(new FormData(form).getAll("fruit")).toEqual(["apple"]);
+      controller.destroy();
+    });
+
+    it("exempts disabled required selects from validation", () => {
+      const { root, controller } = setup({ name: "fruit", required: true, disabled: true });
+      const form = document.createElement("form");
+      root.parentElement?.insertBefore(form, root);
+      form.appendChild(root);
+
+      expect(form.checkValidity()).toBe(true);
+      controller.destroy();
+    });
     it("creates hidden input when name is provided", () => {
       const { root, controller } = setup({ name: "fruit" });
 

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -1252,6 +1252,28 @@ describe("Select", () => {
       expect(trigger.hasAttribute("aria-invalid")).toBe(false);
       controller.destroy();
     });
+
+    it("blocks requestSubmit while invalid and submits one selected value once valid", () => {
+      document.body.innerHTML = `<form><div data-slot="select" data-name="fruit" data-required><button data-slot="select-trigger"><span data-slot="select-value"></span></button><div data-slot="select-content"><div data-slot="select-item" data-value="apple">Apple</div></div></div></form>`;
+      const root = document.querySelector('[data-slot="select"]') as HTMLElement;
+      const form = document.querySelector("form")!;
+      const field = form.elements.namedItem("fruit") as HTMLInputElement;
+      const controller = createSelect(root);
+      let invalidWasCancelled = false;
+      let submits = 0;
+      field.addEventListener("invalid", (event) => { invalidWasCancelled = event.defaultPrevented; });
+      form.addEventListener("submit", (event) => { event.preventDefault(); submits += 1; });
+
+      form.requestSubmit();
+      expect(submits).toBe(0);
+      expect(invalidWasCancelled).toBe(true);
+
+      controller.select("apple");
+      form.requestSubmit();
+      expect(submits).toBe(1);
+      expect(new FormData(form).getAll("fruit")).toEqual(["apple"]);
+      controller.destroy();
+    });
     it("creates hidden input when name is provided", () => {
       const { root, controller } = setup({ name: "fruit" });
 

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -1235,6 +1235,23 @@ describe("Select", () => {
       expect(form.checkValidity()).toBe(true);
       controller.destroy();
     });
+
+    it("routes reportValidity to the trigger and clears invalid state after selection", () => {
+      document.body.innerHTML = `<form><div data-slot="select" data-name="fruit" data-required><button data-slot="select-trigger"><span data-slot="select-value"></span></button><div data-slot="select-content"><div data-slot="select-item" data-value="apple">Apple</div></div></div></form>`;
+      const root = document.querySelector('[data-slot="select"]') as HTMLElement;
+      const form = document.querySelector("form")!;
+      const trigger = root.querySelector('[data-slot="select-trigger"]') as HTMLElement;
+      const controller = createSelect(root);
+      expect(form.reportValidity()).toBe(false);
+      expect(document.activeElement).toBe(trigger);
+      expect(trigger.getAttribute("aria-invalid")).toBe("true");
+      controller.select("");
+      expect(trigger.getAttribute("aria-invalid")).toBe("true");
+      controller.select("apple");
+      expect(form.checkValidity()).toBe(true);
+      expect(trigger.hasAttribute("aria-invalid")).toBe(false);
+      controller.destroy();
+    });
     it("creates hidden input when name is provided", () => {
       const { root, controller } = setup({ name: "fruit" });
 

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -1257,13 +1257,14 @@ describe("Select", () => {
       document.body.innerHTML = `<form><div data-slot="select" data-name="fruit" data-required><button data-slot="select-trigger"><span data-slot="select-value"></span></button><div data-slot="select-content"><div data-slot="select-item" data-value="apple">Apple</div></div></div></form>`;
       const root = document.querySelector('[data-slot="select"]') as HTMLElement;
       const form = document.querySelector("form")!;
-      const field = form.elements.namedItem("fruit") as HTMLInputElement;
       const controller = createSelect(root);
+      const proxy = root.querySelector('input[name="fruit"]') as HTMLInputElement;
       let invalidWasCancelled = false;
       let submits = 0;
-      field.addEventListener("invalid", (event) => { invalidWasCancelled = event.defaultPrevented; });
+      proxy.addEventListener("invalid", (event) => { invalidWasCancelled = event.defaultPrevented; });
       form.addEventListener("submit", (event) => { event.preventDefault(); submits += 1; });
 
+      expect(proxy).toBeTruthy();
       form.requestSubmit();
       expect(submits).toBe(0);
       expect(invalidWasCancelled).toBe(true);

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -1210,6 +1210,46 @@ describe("Select", () => {
       return { ...fields, form };
     };
 
+    it.each([
+      ["LF", "apple\nbanana"],
+      ["CR", "apple\rbanana"],
+      ["CRLF", "apple\r\nbanana"],
+      ["only LF", "\n"],
+      ["only CR", "\r"],
+      ["only CRLF", "\r\n"],
+      ["surrounding whitespace", " \tapple\n "],
+    ])("preserves %s values through selection, validation, and reset", async (_label, value) => {
+      const { controller, form, root } = setupRequiredForm(value);
+      const before = document.createElement("input");
+      before.type = "hidden";
+      before.name = "fruit";
+      before.value = "before";
+      root.before(before);
+      const after = before.cloneNode() as HTMLInputElement;
+      after.value = "after";
+      root.after(after);
+
+      expect(controller.value).toBe(value);
+      expect(form.checkValidity()).toBe(true);
+      expect(new FormData(form).getAll("fruit")).toEqual(["before", value, "after"]);
+
+      const changedValue = `${value}\r\nchanged`;
+      controller.select(changedValue);
+      expect(new FormData(form).getAll("fruit")).toEqual(["before", changedValue, "after"]);
+      form.reset();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(new FormData(form).getAll("fruit")).toEqual(["before", value, "after"]);
+      expect(controller.value).toBe(value);
+      expect(form.checkValidity()).toBe(true);
+
+      controller.select("");
+      expect(form.checkValidity()).toBe(false);
+      expect(new FormData(form).getAll("fruit")).toEqual(["before", "", "after"]);
+      expect(root.querySelectorAll("[data-form-field-generated]").length).toBe(1);
+      controller.destroy();
+      expect(root.querySelector("[data-form-field-generated]")).toBeNull();
+    });
+
     it.each(["apple", undefined])("restores required validation and one form value on reset (default %s)", async (defaultValue) => {
       const { controller, form, root, valueSlot } = setupRequiredForm(defaultValue);
       controller.select("banana");
@@ -1230,10 +1270,7 @@ describe("Select", () => {
     it("preserves a required selection made inside a reset listener", async () => {
       const { controller, form } = setupRequiredForm("apple");
       form.addEventListener("reset", () => controller.select("banana"));
-      // Happy DOM resets before dispatch; browsers reset after the listeners.
-      form.dispatchEvent(new Event("reset", { bubbles: true, cancelable: true }));
-      const proxy = form.elements.namedItem("fruit") as HTMLInputElement;
-      proxy.value = proxy.defaultValue;
+      form.reset();
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(controller.value).toBe("banana");
@@ -1307,7 +1344,7 @@ describe("Select", () => {
       const controller = createSelect(root);
 
       expect(form.checkValidity()).toBe(false);
-      const field = form.elements.namedItem("fruit") as HTMLInputElement;
+      const field = form.elements.namedItem("fruit") as HTMLSelectElement;
       expect(field.validity.valueMissing).toBe(true);
       expect(field.tabIndex).toBe(-1);
       expect(document.activeElement).toBe(trigger);
@@ -1350,7 +1387,7 @@ describe("Select", () => {
       const root = document.querySelector('[data-slot="select"]') as HTMLElement;
       const form = document.querySelector("form")!;
       const controller = createSelect(root);
-      const proxy = root.querySelector('input[name="fruit"]') as HTMLInputElement;
+      const proxy = form.elements.namedItem("fruit") as HTMLSelectElement;
       let invalidWasCancelled = false;
       let submits = 0;
       proxy.addEventListener("invalid", (event) => { invalidWasCancelled = event.defaultPrevented; });

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -462,7 +462,7 @@ export function createSelect(
     // Update hidden input
     if (hiddenInput) {
       hiddenInput.value = value ?? "";
-      const invalid = required && !disabled && value === null;
+      const invalid = required && !disabled && !value;
       if (invalid) trigger.setAttribute("aria-invalid", "true");
       else trigger.removeAttribute("aria-invalid");
     }

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -178,7 +178,13 @@ export function createSelect(
         whiteSpace: "nowrap",
         border: "0",
       });
-      cleanups.push(on(hiddenInput, "invalid", () => trigger.focus()));
+      cleanups.push(on(hiddenInput, "invalid", (event) => {
+        // Keep the browser from moving focus to the off-screen proxy.
+        event.preventDefault();
+        trigger.setAttribute("aria-invalid", "true");
+        trigger.focus();
+        requestAnimationFrame(() => trigger.focus());
+      }));
     }
     root.appendChild(hiddenInput);
   }
@@ -456,6 +462,9 @@ export function createSelect(
     // Update hidden input
     if (hiddenInput) {
       hiddenInput.value = value ?? "";
+      const invalid = required && !disabled && value === null;
+      if (invalid) trigger.setAttribute("aria-invalid", "true");
+      else trigger.removeAttribute("aria-invalid");
     }
 
     // Update root data-value

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -156,9 +156,30 @@ export function createSelect(
   // Create hidden input for form integration
   if (name) {
     hiddenInput = document.createElement("input");
-    hiddenInput.type = "hidden";
+    // A hidden input is exempt from constraint validation. Keep this field out
+    // of the visual and keyboard flow instead, so native required validation
+    // can represent the custom select without creating a second form value.
+    hiddenInput.type = required ? "text" : "hidden";
     hiddenInput.name = name;
     hiddenInput.value = currentValue ?? "";
+    hiddenInput.required = required;
+    hiddenInput.disabled = disabled;
+    if (required) {
+      hiddenInput.tabIndex = -1;
+      hiddenInput.setAttribute("aria-hidden", "true");
+      Object.assign(hiddenInput.style, {
+        position: "absolute",
+        width: "1px",
+        height: "1px",
+        padding: "0",
+        margin: "-1px",
+        overflow: "hidden",
+        clip: "rect(0, 0, 0, 0)",
+        whiteSpace: "nowrap",
+        border: "0",
+      });
+      cleanups.push(on(hiddenInput, "invalid", () => trigger.focus()));
+    }
     root.appendChild(hiddenInput);
   }
 

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -22,7 +22,7 @@ export interface SelectOptions {
   disabled?: boolean;
   /** Form validation required */
   required?: boolean;
-  /** Form field name (auto-creates hidden input) */
+  /** Form field name (auto-creates an internal form control) */
   name?: string;
 
   /**


### PR DESCRIPTION
Required Selects previously used a hidden input, so an empty selection could pass native validation and submit. Named Selects with `required` / `data-required` now block submission until a value is selected, including through `requestSubmit()`, and participate in `checkValidity()` and `reportValidity()`.

This builds on the shared form adapter merged in #14:

- Add required validation to the adapter’s single generated form control, keeping it out of the visual and keyboard flow without duplicating submitted values.
- Set validation state on the visible trigger and route focus in form order, including forms with multiple Selects and native fields. Cancel deferred focus when the value changes or the controller is destroyed.
- Preserve default selections, canceled resets, and selections made inside reset listeners. Disabled Selects remain excluded from validation and submission.
- Preserve selected values exactly, including CR/LF and newline-only values, using a visually hidden native select with one option.
- Add regression coverage and update Select’s form integration documentation.

Validation:
- `bun test`: 1,325 passing tests.
- Native browser verification: 93 passing checks covering required submission, exact values including line breaks, reset lifecycle, duplicate values, focus order, disabled fieldsets, and cleanup.
- `bun run build`: passes.
- `bun run typecheck`: 143 existing diagnostics, matching current `main` after normalizing line and column positions; no new diagnostics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/data-slot/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791630028&installation_model_id=433409&pr_number=15&repository=bejamas%2Fdata-slot&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fdata-slot%2Fpull%2F15&signature=afbc550253457f70475455100aff831b4e1af6d0fb76e3dea2f7ab5b042e02ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->