### PR TITLE
fix: centralize focus discovery and correct keyboard navigation

### DIFF
--- a/packages/alert-dialog/src/index.test.ts
+++ b/packages/alert-dialog/src/index.test.ts
@@ -63,6 +63,44 @@ describe("AlertDialog", () => {
     };
   };
 
+
+  for (const singleControl of [true, false]) {
+    for (const shiftKey of [false, true]) {
+      it(`moves ${shiftKey ? "backward" : "forward"} from programmatic focus with ${singleControl ? "one tabbable control" : "two tabbable controls"}`, async () => {
+        const { title, cancel, action, controller } = setup();
+        title.setAttribute("tabindex", "-1");
+        if (singleControl) action.remove();
+        try {
+          controller.open();
+          await waitForRaf();
+          expect(document.activeElement?.getAttribute("data-slot")).toBe("alert-dialog-title");
+          const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey, bubbles: true, cancelable: true });
+          title.dispatchEvent(event);
+          expect(event.defaultPrevented).toBe(true);
+          expect(document.activeElement).toBe(shiftKey && !singleControl ? action : cancel);
+        } finally {
+          controller.destroy();
+        }
+      });
+    }
+  }
+
+  it("focuses the content when no eligible descendants remain", async () => {
+    const { content, controller } = setup();
+    content.innerHTML = '<summary>Not focusable</summary><button hidden>Hidden</button>';
+    try {
+      controller.open();
+      await waitForRaf();
+      expect(document.activeElement).toBe(content);
+      const event = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+      content.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(content);
+    } finally {
+      controller.destroy();
+    }
+  });
+
   beforeEach(() => {
     document.body.innerHTML = "";
   });

--- a/packages/alert-dialog/src/index.test.ts
+++ b/packages/alert-dialog/src/index.test.ts
@@ -335,4 +335,37 @@ describe("AlertDialog", () => {
 
     alertController.destroy();
   });
+
+  it("traps Tab among currently tabbable controls, skipping hidden, inert, and newly disabled descendants", async () => {
+    document.body.innerHTML = `
+      <div data-slot="alert-dialog" id="alert-root">
+        <div data-slot="alert-dialog-overlay"></div>
+        <div data-slot="alert-dialog-content">
+          <div hidden><button id="hidden-control">Hidden</button></div>
+          <div inert><button id="inert-control">Inert</button></div>
+          <button id="first-control">First</button>
+          <button id="last-control">Last</button>
+        </div>
+      </div>
+    `;
+    const root = document.getElementById("alert-root")!;
+    const controller = createAlertDialog(root);
+    const first = document.getElementById("first-control") as HTMLButtonElement;
+    const last = document.getElementById("last-control") as HTMLButtonElement;
+
+    controller.open();
+    await waitForRaf();
+    expect(document.activeElement).toBe(first);
+
+    last.focus();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    expect(document.activeElement).toBe(first);
+
+    last.disabled = true;
+    first.focus();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    expect(document.activeElement).toBe(first);
+
+    controller.destroy();
+  });
 });

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -16,7 +16,7 @@ import {
   createDismissLayer,
   createPresenceLifecycle,
   focusElement,
-  getFocusable,
+  getAutofocusOrFirstFocusable,
   getTabbables,
 } from "@data-slot/core";
 
@@ -125,11 +125,8 @@ export function createAlertDialog(
   };
 
   const focusFirst = () => {
-    const autofocusEl = getFocusable(content).find((element) => element.hasAttribute("autofocus"));
-    if (autofocusEl) return autofocusEl.focus();
-
-    const first = getFocusable(content)[0];
-    if (first) return first.focus();
+    const initialFocus = getAutofocusOrFirstFocusable(content);
+    if (initialFocus) return initialFocus.focus();
 
     ensureContentFocusable();
     content.focus();

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -218,9 +218,10 @@ export function createAlertDialog(
     const last = focusables[focusables.length - 1]!;
     const active = content.ownerDocument.activeElement;
 
-    if (!content.contains(active)) {
+    // Initial or programmatic focus may be inside the dialog but outside its tab order.
+    if (!focusables.includes(active as HTMLElement)) {
       e.preventDefault();
-      first.focus();
+      (e.shiftKey ? last : first).focus();
       return;
     }
 

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -16,6 +16,8 @@ import {
   createDismissLayer,
   createPresenceLifecycle,
   focusElement,
+  getFocusable,
+  getTabbables,
 } from "@data-slot/core";
 
 export interface AlertDialogOptions {
@@ -47,9 +49,6 @@ export interface AlertDialogController {
 const ROOT_BINDING_KEY = "@data-slot/alert-dialog";
 const DUPLICATE_BINDING_WARNING =
   "[@data-slot/alert-dialog] createAlertDialog() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
-
-const FOCUSABLE =
-  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
 export function createAlertDialog(
   root: Element,
@@ -126,10 +125,10 @@ export function createAlertDialog(
   };
 
   const focusFirst = () => {
-    const autofocusEl = content.querySelector<HTMLElement>("[autofocus]");
+    const autofocusEl = getFocusable(content).find((element) => element.hasAttribute("autofocus"));
     if (autofocusEl) return autofocusEl.focus();
 
-    const first = content.querySelector<HTMLElement>(FOCUSABLE);
+    const first = getFocusable(content)[0];
     if (first) return first.focus();
 
     ensureContentFocusable();
@@ -209,7 +208,7 @@ export function createAlertDialog(
   const handleKeydown = (e: KeyboardEvent) => {
     if (e.key !== "Tab") return;
 
-    const focusables = content.querySelectorAll<HTMLElement>(FOCUSABLE);
+    const focusables = getTabbables(content);
 
     if (focusables.length === 0) {
       e.preventDefault();
@@ -220,7 +219,7 @@ export function createAlertDialog(
 
     const first = focusables[0]!;
     const last = focusables[focusables.length - 1]!;
-    const active = document.activeElement;
+    const active = content.ownerDocument.activeElement;
 
     if (!content.contains(active)) {
       e.preventDefault();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -36,6 +36,21 @@ Find all component roots within a scope by data-slot value.
 const dialogs = getRoots(document, "dialog");
 ```
 
+### Focus Utilities
+
+`getFocusable(container)` returns programmatically focusable descendants in DOM
+order, including elements with a negative `tabindex`. `getTabbables(container)`
+returns the subset eligible for Tab navigation, accounting for checked radio
+groups. It also returns DOM order rather than sorting positive `tabindex` values.
+
+`getAutofocusOrFirstFocusable(container)` selects an eligible `[autofocus]`
+descendant, otherwise the first focusable descendant, or `undefined` if none exist.
+
+Each call reads current DOM state. Hidden, inert, and natively disabled controls
+are excluded. `aria-disabled` and `data-disabled` alone do not remove native focus
+eligibility. Queries exclude the container itself and do not cross into nested
+shadow roots; pass a shadow root directly to query its descendants.
+
 ### ARIA Utilities
 
 #### `ensureId(element, prefix)`
@@ -116,4 +131,3 @@ function createCustomComponent(root: Element) {
 ## License
 
 MIT
-

--- a/packages/core/src/focus.test.ts
+++ b/packages/core/src/focus.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { getAutofocusOrFirstFocusable, getFocusable, getTabbables } from './focus'
+
+describe('focus eligibility', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('honors visibility overrides without overriding display-none ancestors', () => {
+    document.body.innerHTML = `
+      <div style="visibility: hidden">
+        <button id="inherited">Hidden</button>
+        <button id="visible" style="visibility: visible">Visible</button>
+      </div>
+      <div style="display: none">
+        <button style="visibility: visible">Still hidden</button>
+      </div>
+    `
+    expect(getTabbables(document.body).map((element) => element.id)).toEqual(['visible'])
+  })
+
+  it('only includes the first summary of a details element unless tabindex is explicit', () => {
+    document.body.innerHTML = `
+      <summary>Standalone</summary>
+      <details open>
+        <summary id="first">First</summary>
+        <summary>Second</summary>
+        <summary id="explicit" tabindex="-1">Programmatic</summary>
+      </details>
+      <summary id="standalone" tabindex="0">Explicit standalone</summary>
+    `
+    expect(getFocusable(document.body).map((element) => element.id)).toEqual(['first', 'explicit', 'standalone'])
+    expect(getTabbables(document.body).map((element) => element.id)).toEqual(['first', 'standalone'])
+  })
+
+  it('distinguishes editing hosts from nested editable content and respects tabindex', () => {
+    document.body.innerHTML = `
+      <div id="editor" contenteditable="true">
+        <div contenteditable="true">Nested</div>
+        <div><div contenteditable="plaintext-only">Inherited through a wrapper</div></div>
+        <div id="nested-tab" contenteditable="true" tabindex="0">Tabbable</div>
+        <div id="nested-focus" contenteditable="true" tabindex="-1">Programmatic</div>
+        <div contenteditable="false"><div id="new-host" contenteditable="TRUE">New host</div></div>
+        <button id="button">Native control</button>
+      </div>
+      <div contenteditable="invalid">Not editable</div>
+    `
+    expect(getFocusable(document.body).map((element) => element.id)).toEqual([
+      'editor', 'nested-tab', 'nested-focus', 'new-host', 'button',
+    ])
+    expect(getTabbables(document.body).map((element) => element.id)).toEqual([
+      'editor', 'nested-tab', 'new-host', 'button',
+    ])
+  })
+
+  it('does not let hidden inputs or invalid tabindex targets prevent autofocus fallback', () => {
+    document.body.innerHTML = `
+      <input type="hidden" tabindex="0" autofocus>
+      <div tabindex="invalid" autofocus>Invalid</div>
+      <summary autofocus>Standalone</summary>
+      <button id="action">Action</button>
+    `
+    expect(getFocusable(document.body).map((element) => element.id)).toEqual(['action'])
+    expect(getAutofocusOrFirstFocusable(document.body)?.id).toBe('action')
+  })
+
+  it('refreshes radio selection and form ownership between discoveries', () => {
+    document.body.innerHTML = `
+      <form id="form"><input id="inside" type="radio" name="plan"></form>
+      <input id="outside" type="radio" name="plan" form="form" checked>
+    `
+    const form = document.getElementById('form')!
+    const inside = document.getElementById('inside') as HTMLInputElement
+    const outside = document.getElementById('outside') as HTMLInputElement
+    expect(getTabbables(form)).toEqual([])
+    outside.checked = false
+    inside.checked = true
+    expect(getTabbables(form)).toEqual([inside])
+    inside.checked = false
+    outside.checked = true
+    expect(getTabbables(form)).toEqual([])
+    outside.removeAttribute('form')
+    expect(getTabbables(form)).toEqual([inside])
+    outside.setAttribute('form', 'form')
+    expect(getTabbables(form)).toEqual([])
+    outside.disabled = true
+    expect(getTabbables(form)).toEqual([inside])
+  })
+})

--- a/packages/core/src/focus.ts
+++ b/packages/core/src/focus.ts
@@ -29,8 +29,8 @@ function isInert(element: HTMLElement): boolean {
 function isVisible(element: HTMLElement): boolean {
   for (let current: HTMLElement | null = element; current; current = current.parentElement) {
     if (current.hidden) return false
-    const view = current.ownerDocument.defaultView
-    const style = view?.getComputedStyle(current)
+    const ownerWindow: Window | null = current.ownerDocument.defaultView
+    const style = ownerWindow?.getComputedStyle(current)
     if (style?.display === 'none' || style?.visibility === 'hidden' || style?.visibility === 'collapse') {
       return false
     }
@@ -38,31 +38,49 @@ function isVisible(element: HTMLElement): boolean {
   return true
 }
 
+function isHiddenByClosedDetails(element: HTMLElement): boolean {
+  const details = element.closest('details:not([open])')
+  if (!details) return false
+  const firstSummary = Array.from(details.children).find((child) => child.tagName === 'SUMMARY')
+  return firstSummary !== element
+}
+
 function isDisabledByFieldset(element: HTMLElement): boolean {
   if (!element.matches('button, input, select, textarea, option, optgroup')) return false
   const fieldset = element.closest('fieldset[disabled]')
   if (!fieldset) return false
   const firstLegend = Array.from(fieldset.children).find((child) => child.tagName === 'LEGEND')
-  return !(firstLegend instanceof HTMLElement && firstLegend.contains(element))
+  return !(firstLegend?.contains(element))
 }
 
 function isFocusable(element: HTMLElement): boolean {
   if (element.matches(':disabled') || isDisabledByFieldset(element)) return false
-  return isVisible(element) && !isInert(element)
+  return isVisible(element) && !isInert(element) && !isHiddenByClosedDetails(element)
 }
 
 function isRadioTabbable(element: HTMLElement): boolean {
   const Input = element.ownerDocument.defaultView?.HTMLInputElement
   if (!Input || !(element instanceof Input) || element.type !== 'radio' || !element.name) return true
-  const scope = element.form ?? element.ownerDocument
-  const radios = Array.from(scope.querySelectorAll<HTMLInputElement>('input[type="radio"]'))
-    .filter((radio) => radio.name === element.name && isFocusable(radio))
+  const tree = element.getRootNode()
+  const radios = Array.from(element.ownerDocument.querySelectorAll<HTMLInputElement>('input[type="radio"]'))
+    .filter((radio) =>
+      radio.name === element.name &&
+      radio.form === element.form &&
+      radio.getRootNode() === tree &&
+      isFocusable(radio),
+    )
   const checked = radios.find((radio) => radio.checked)
   return !checked || checked === element
 }
 
 export function getFocusable(container: ParentNode): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(isFocusable)
+}
+
+/** Returns the valid autofocus target when present, otherwise the first focusable descendant. */
+export function getAutofocusOrFirstFocusable(container: ParentNode): HTMLElement | undefined {
+  const focusables = getFocusable(container)
+  return focusables.find((element) => element.hasAttribute('autofocus')) ?? focusables[0]
 }
 
 export function getTabbables(container: ParentNode): HTMLElement[] {

--- a/packages/core/src/focus.ts
+++ b/packages/core/src/focus.ts
@@ -39,10 +39,12 @@ function isVisible(element: HTMLElement): boolean {
 }
 
 function isHiddenByClosedDetails(element: HTMLElement): boolean {
-  const details = element.closest('details:not([open])')
-  if (!details) return false
-  const firstSummary = Array.from(details.children).find((child) => child.tagName === 'SUMMARY')
-  return firstSummary !== element
+  for (let current: HTMLElement | null = element.parentElement; current; current = current.parentElement) {
+    if (current.tagName !== 'DETAILS' || current.hasAttribute('open')) continue
+    const firstSummary = Array.from(current.children).find((child) => child.tagName === 'SUMMARY')
+    if (!firstSummary?.contains(element)) return true
+  }
+  return false
 }
 
 function isDisabledByFieldset(element: HTMLElement): boolean {
@@ -58,15 +60,26 @@ function isFocusable(element: HTMLElement): boolean {
   return isVisible(element) && !isInert(element) && !isHiddenByClosedDetails(element)
 }
 
+function getFocusTree(element: HTMLElement): ParentNode {
+  const root = element.getRootNode()
+  if (root !== element) return root as ParentNode
+
+  // Some lightweight DOM implementations return the element itself here for
+  // shadow-tree descendants. Preserve native semantics by walking to its root.
+  let current: Node = element
+  while (current.parentNode) current = current.parentNode
+  return current as ParentNode
+}
+
 function isRadioTabbable(element: HTMLElement): boolean {
   const Input = element.ownerDocument.defaultView?.HTMLInputElement
   if (!Input || !(element instanceof Input) || element.type !== 'radio' || !element.name) return true
-  const tree = element.getRootNode()
-  const radios = Array.from(element.ownerDocument.querySelectorAll<HTMLInputElement>('input[type="radio"]'))
+  const tree = getFocusTree(element)
+  const radios = Array.from(tree.querySelectorAll<HTMLInputElement>('input[type="radio"]'))
     .filter((radio) =>
       radio.name === element.name &&
       radio.form === element.form &&
-      radio.getRootNode() === tree &&
+      getFocusTree(radio) === tree &&
       isFocusable(radio),
     )
   const checked = radios.find((radio) => radio.checked)

--- a/packages/core/src/focus.ts
+++ b/packages/core/src/focus.ts
@@ -2,20 +2,18 @@
  * Focusable descendants are elements that may receive programmatic focus.
  * Tabbables are the subset that participate in sequential keyboard navigation.
  */
-const FOCUSABLE_SELECTOR = [
+const NATIVE_FOCUSABLE_SELECTOR = [
   'a[href]',
   'area[href]',
   'button',
   'input:not([type="hidden"])',
   'select',
   'textarea',
-  'summary',
   'iframe',
   'audio[controls]',
   'video[controls]',
-  '[contenteditable]:not([contenteditable="false"])',
-  '[tabindex]',
 ].join(', ')
+const FOCUSABLE_SELECTOR = `${NATIVE_FOCUSABLE_SELECTOR}, summary, [contenteditable], [tabindex]`
 
 function isInert(element: HTMLElement): boolean {
   for (let current: HTMLElement | null = element; current; current = current.parentElement) {
@@ -27,11 +25,14 @@ function isInert(element: HTMLElement): boolean {
 }
 
 function isVisible(element: HTMLElement): boolean {
+  const visibility = element.ownerDocument.defaultView?.getComputedStyle(element).visibility
+  if (visibility === 'hidden' || visibility === 'collapse') return false
+
   for (let current: HTMLElement | null = element; current; current = current.parentElement) {
     if (current.hidden) return false
     const ownerWindow: Window | null = current.ownerDocument.defaultView
     const style = ownerWindow?.getComputedStyle(current)
-    if (style?.display === 'none' || style?.visibility === 'hidden' || style?.visibility === 'collapse') {
+    if (style?.display === 'none') {
       return false
     }
   }
@@ -56,8 +57,33 @@ function isDisabledByFieldset(element: HTMLElement): boolean {
 }
 
 function isFocusable(element: HTMLElement): boolean {
+  if (!hasFocusSemantics(element)) return false
   if (element.matches(':disabled') || isDisabledByFieldset(element)) return false
   return isVisible(element) && !isInert(element) && !isHiddenByClosedDetails(element)
+}
+
+function isEditable(element: HTMLElement | null): boolean {
+  for (let current = element; current; current = current.parentElement) {
+    const value = current.getAttribute('contenteditable')?.toLowerCase()
+    if (value === 'false') return false
+    if (value === '' || value === 'true' || value === 'plaintext-only') return true
+  }
+  return false
+}
+
+function hasFocusSemantics(element: HTMLElement): boolean {
+  // Hidden inputs cannot receive focus even with an explicit tabindex.
+  if (element.matches('input[type="hidden"]')) return false
+  const tabindex = element.getAttribute('tabindex')
+  if (tabindex !== null && !Number.isNaN(Number.parseInt(tabindex, 10))) return true
+  if (element.matches(NATIVE_FOCUSABLE_SELECTOR)) return true
+  if (element.tagName === 'SUMMARY' && element.parentElement?.tagName === 'DETAILS') {
+    const firstSummary = Array.from(element.parentElement.children).find((child) => child.tagName === 'SUMMARY')
+    if (firstSummary === element) return true
+  }
+  // Only an editing host has intrinsic focusability; nested editable elements
+  // need their own tabindex unless a non-editable ancestor starts a new host.
+  return isEditable(element) && !isEditable(element.parentElement)
 }
 
 function getFocusTree(element: HTMLElement): ParentNode {
@@ -71,19 +97,18 @@ function getFocusTree(element: HTMLElement): ParentNode {
   return current as ParentNode
 }
 
-function isRadioTabbable(element: HTMLElement): boolean {
-  const Input = element.ownerDocument.defaultView?.HTMLInputElement
-  if (!Input || !(element instanceof Input) || element.type !== 'radio' || !element.name) return true
-  const tree = getFocusTree(element)
-  const radios = Array.from(tree.querySelectorAll<HTMLInputElement>('input[type="radio"]'))
-    .filter((radio) =>
-      radio.name === element.name &&
-      radio.form === element.form &&
-      getFocusTree(radio) === tree &&
-      isFocusable(radio),
-    )
-  const checked = radios.find((radio) => radio.checked)
-  return !checked || checked === element
+function getCheckedRadioGroups(tree: ParentNode): Map<HTMLFormElement | null, Map<string, HTMLInputElement>> {
+  const groups = new Map<HTMLFormElement | null, Map<string, HTMLInputElement>>()
+  for (const radio of tree.querySelectorAll<HTMLInputElement>('input[type="radio"]:checked')) {
+    if (!radio.name || getFocusTree(radio) !== tree || !isFocusable(radio)) continue
+    let names = groups.get(radio.form)
+    if (!names) {
+      names = new Map()
+      groups.set(radio.form, names)
+    }
+    if (!names.has(radio.name)) names.set(radio.name, radio)
+  }
+  return groups
 }
 
 export function getFocusable(container: ParentNode): HTMLElement[] {
@@ -97,8 +122,21 @@ export function getAutofocusOrFirstFocusable(container: ParentNode): HTMLElement
 }
 
 export function getTabbables(container: ParentNode): HTMLElement[] {
+  // Keep discovery local to this call so checked state, form ownership and
+  // visibility changes are reflected on the next keyboard interaction.
+  const radioGroups = new Map<ParentNode, ReturnType<typeof getCheckedRadioGroups>>()
   return getFocusable(container).filter((element) => {
     const tabindex = element.getAttribute('tabindex')
-    return (tabindex === null || Number(tabindex) >= 0) && isRadioTabbable(element)
+    if (tabindex !== null && Number.parseInt(tabindex, 10) < 0) return false
+    const Input = element.ownerDocument.defaultView?.HTMLInputElement
+    if (!Input || !(element instanceof Input) || element.type !== 'radio' || !element.name) return true
+    const tree = getFocusTree(element)
+    let groups = radioGroups.get(tree)
+    if (!groups) {
+      groups = getCheckedRadioGroups(tree)
+      radioGroups.set(tree, groups)
+    }
+    const checked = groups.get(element.form)?.get(element.name)
+    return !checked || checked === element
   })
 }

--- a/packages/core/src/focus.ts
+++ b/packages/core/src/focus.ts
@@ -1,0 +1,73 @@
+/**
+ * Focusable descendants are elements that may receive programmatic focus.
+ * Tabbables are the subset that participate in sequential keyboard navigation.
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button',
+  'input:not([type="hidden"])',
+  'select',
+  'textarea',
+  'summary',
+  'iframe',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]',
+].join(', ')
+
+function isInert(element: HTMLElement): boolean {
+  for (let current: HTMLElement | null = element; current; current = current.parentElement) {
+    if (current.hasAttribute('inert') || (current as HTMLElement & { inert?: boolean }).inert) {
+      return true
+    }
+  }
+  return false
+}
+
+function isVisible(element: HTMLElement): boolean {
+  for (let current: HTMLElement | null = element; current; current = current.parentElement) {
+    if (current.hidden) return false
+    const view = current.ownerDocument.defaultView
+    const style = view?.getComputedStyle(current)
+    if (style?.display === 'none' || style?.visibility === 'hidden' || style?.visibility === 'collapse') {
+      return false
+    }
+  }
+  return true
+}
+
+function isDisabledByFieldset(element: HTMLElement): boolean {
+  if (!element.matches('button, input, select, textarea, option, optgroup')) return false
+  const fieldset = element.closest('fieldset[disabled]')
+  if (!fieldset) return false
+  const firstLegend = Array.from(fieldset.children).find((child) => child.tagName === 'LEGEND')
+  return !(firstLegend instanceof HTMLElement && firstLegend.contains(element))
+}
+
+function isFocusable(element: HTMLElement): boolean {
+  if (element.matches(':disabled') || isDisabledByFieldset(element)) return false
+  return isVisible(element) && !isInert(element)
+}
+
+function isRadioTabbable(element: HTMLElement): boolean {
+  const Input = element.ownerDocument.defaultView?.HTMLInputElement
+  if (!Input || !(element instanceof Input) || element.type !== 'radio' || !element.name) return true
+  const scope = element.form ?? element.ownerDocument
+  const radios = Array.from(scope.querySelectorAll<HTMLInputElement>('input[type="radio"]'))
+    .filter((radio) => radio.name === element.name && isFocusable(radio))
+  const checked = radios.find((radio) => radio.checked)
+  return !checked || checked === element
+}
+
+export function getFocusable(container: ParentNode): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(isFocusable)
+}
+
+export function getTabbables(container: ParentNode): HTMLElement[] {
+  return getFocusable(container).filter((element) => {
+    const tabindex = element.getAttribute('tabindex')
+    return (tabindex === null || Number(tabindex) >= 0) && isRadioTabbable(element)
+  })
+}

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -18,7 +18,7 @@ import { ensureId, setAria, linkLabelledBy } from './index'
 import { on, emit, composeHandlers } from './index'
 import { lockScroll, unlockScroll } from './index'
 import { createTypeahead } from './index'
-import { getFocusable, getTabbables } from './index'
+import { getAutofocusOrFirstFocusable, getFocusable, getTabbables } from './index'
 import { containsWithPortals, portalToBody, restorePortal } from './index'
 import {
   computeFloatingPosition,
@@ -76,6 +76,44 @@ describe('core/focusability', () => {
     expect(getTabbables(root).map((element) => element.id)).toEqual(['selected'])
     root.setAttribute('inert', '')
     expect(getFocusable(root)).toEqual([])
+  })
+
+  it('groups radios by form owner or tree, including form-associated controls outside the form', () => {
+    document.body.innerHTML = `
+      <form id="first-form"><input id="first-form-radio" type="radio" name="plan"></form>
+      <form id="second-form"><input id="second-form-radio" type="radio" name="plan" checked></form>
+      <input id="associated-radio" type="radio" name="plan" form="first-form" checked>
+      <div id="root"><input id="unowned-radio" type="radio" name="plan"></div>
+    `
+    const root = document.getElementById('root')!
+    const firstForm = document.getElementById('first-form')!
+
+    expect(getTabbables(firstForm).map((element) => element.id)).toEqual([])
+    expect(getTabbables(root).map((element) => element.id)).toEqual(['unowned-radio'])
+  })
+
+  it('excludes descendants of closed details except its first summary', () => {
+    document.body.innerHTML = `
+      <div id="root">
+        <details><summary id="summary">Summary</summary><button id="closed-control">Closed</button></details>
+        <details open><summary id="open-summary">Open summary</summary><button id="open-control">Open</button></details>
+      </div>
+    `
+    const root = document.getElementById('root')!
+
+    expect(getFocusable(root).map((element) => element.id)).toEqual(['summary', 'open-summary', 'open-control'])
+  })
+
+  it('prefers a valid autofocus target over the first focusable descendant', () => {
+    document.body.innerHTML = `
+      <div id="root">
+        <button id="first">First</button>
+        <button id="hidden-autofocus" hidden autofocus>Hidden</button>
+        <button id="autofocus" autofocus>Autofocus</button>
+      </div>
+    `
+
+    expect(getAutofocusOrFirstFocusable(document.getElementById('root')!)?.id).toBe('autofocus')
   })
 })
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -92,16 +92,49 @@ describe('core/focusability', () => {
     expect(getTabbables(root).map((element) => element.id)).toEqual(['unowned-radio'])
   })
 
-  it('excludes descendants of closed details except its first summary', () => {
+  it('excludes descendants of closed details except content within every first summary', () => {
     document.body.innerHTML = `
       <div id="root">
-        <details><summary id="summary">Summary</summary><button id="closed-control">Closed</button></details>
+        <details>
+          <summary id="summary">Summary <button id="summary-control">Summary control</button><details><summary id="nested-summary-visible">Nested visible summary</summary><button id="nested-visible-control">Nested closed</button></details></summary>
+          <details><summary id="nested-summary-hidden">Nested hidden summary</summary><button id="nested-hidden-control">Nested closed</button></details>
+          <button id="closed-control">Closed</button>
+        </details>
         <details open><summary id="open-summary">Open summary</summary><button id="open-control">Open</button></details>
       </div>
     `
     const root = document.getElementById('root')!
 
-    expect(getFocusable(root).map((element) => element.id)).toEqual(['summary', 'open-summary', 'open-control'])
+    expect(getFocusable(root).map((element) => element.id)).toEqual([
+      'summary',
+      'summary-control',
+      'nested-summary-visible',
+      'open-summary',
+      'open-control',
+    ])
+  })
+
+  it('scopes radio groups to their shadow root or detached fragment', () => {
+    const host = document.createElement('div')
+    const shadow = host.attachShadow({ mode: 'open' })
+    const shadowFirst = document.createElement('input')
+    shadowFirst.id = 'shadow-first'
+    shadowFirst.type = 'radio'
+    shadowFirst.name = 'plan'
+    const shadowSelected = document.createElement('input')
+    shadowSelected.id = 'shadow-selected'
+    shadowSelected.type = 'radio'
+    shadowSelected.name = 'plan'
+    shadowSelected.checked = true
+    shadow.append(shadowFirst, shadowSelected)
+    const fragment = document.createDocumentFragment()
+    const detached = document.createElement('div')
+    detached.innerHTML = `<input id="fragment-first" type="radio" name="plan"><input id="fragment-selected" type="radio" name="plan">`
+    ;(detached.querySelector('#fragment-selected') as HTMLInputElement).checked = true
+    fragment.append(detached)
+
+    expect(getTabbables(shadow).map((element) => element.id)).toEqual(['shadow-selected'])
+    expect(getTabbables(fragment).map((element) => element.id)).toEqual(['fragment-selected'])
   })
 
   it('prefers a valid autofocus target over the first focusable descendant', () => {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -18,6 +18,7 @@ import { ensureId, setAria, linkLabelledBy } from './index'
 import { on, emit, composeHandlers } from './index'
 import { lockScroll, unlockScroll } from './index'
 import { createTypeahead } from './index'
+import { getFocusable, getTabbables } from './index'
 import { containsWithPortals, portalToBody, restorePortal } from './index'
 import {
   computeFloatingPosition,
@@ -33,6 +34,50 @@ import {
 } from './index'
 import type { PortalState } from './index'
 import { getScrollLockCount, resetScrollLock } from './scroll'
+
+describe('core/focusability', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns only visible, enabled focusable descendants and keeps negative tabindex focusable', () => {
+    document.body.innerHTML = `
+      <div id="root">
+        <button id="visible">Visible</button>
+        <button id="hidden" hidden>Hidden</button>
+        <div style="display: none"><button id="display-none">Display none</button></div>
+        <div style="visibility: hidden"><button id="visibility-hidden">Visibility hidden</button></div>
+        <div inert><button id="inert">Inert</button></div>
+        <fieldset disabled><button id="fieldset-disabled">Disabled by fieldset</button></fieldset>
+        <button id="disabled" disabled>Disabled</button>
+        <div id="programmatic" tabindex="-1">Programmatic</div>
+      </div>
+    `
+    const root = document.getElementById('root')!
+
+    expect(getFocusable(root).map((element) => element.id)).toEqual(['visible', 'programmatic'])
+    expect(getTabbables(root).map((element) => element.id)).toEqual(['visible'])
+  })
+
+  it('uses radio-group tabbing semantics and reflects runtime state changes', () => {
+    document.body.innerHTML = `
+      <div id="root">
+        <input id="first" type="radio" name="plan">
+        <input id="selected" type="radio" name="plan" checked>
+        <input id="third" type="radio" name="plan">
+        <button id="action">Action</button>
+      </div>
+    `
+    const root = document.getElementById('root')!
+    const action = document.getElementById('action') as HTMLButtonElement
+
+    expect(getTabbables(root).map((element) => element.id)).toEqual(['selected', 'action'])
+    action.disabled = true
+    expect(getTabbables(root).map((element) => element.id)).toEqual(['selected'])
+    root.setAttribute('inert', '')
+    expect(getFocusable(root)).toEqual([])
+  })
+})
 
 describe('core/parts', () => {
   it('getPart finds a single slot', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,7 @@ export { on, emit, composeHandlers } from "./events.ts";
 export { createFormFieldAdapter, observeFormReset } from "./form-field.ts";
 export type { FormFieldAdapter, FormResetObserver } from "./form-field.ts";
 export { lockScroll, unlockScroll } from "./scroll.ts";
-export { getFocusable, getTabbables } from "./focus.ts";
+export { getAutofocusOrFirstFocusable, getFocusable, getTabbables } from "./focus.ts";
 export {
   computeFloatingPosition,
   computeFloatingTransformOrigin,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export { on, emit, composeHandlers } from "./events.ts";
 export { createFormFieldAdapter, observeFormReset } from "./form-field.ts";
 export type { FormFieldAdapter, FormResetObserver } from "./form-field.ts";
 export { lockScroll, unlockScroll } from "./scroll.ts";
+export { getFocusable, getTabbables } from "./focus.ts";
 export {
   computeFloatingPosition,
   computeFloatingTransformOrigin,

--- a/packages/dialog/src/index.test.ts
+++ b/packages/dialog/src/index.test.ts
@@ -61,6 +61,44 @@ describe("Dialog", () => {
     };
   };
 
+
+  for (const singleControl of [true, false]) {
+    for (const shiftKey of [false, true]) {
+      it(`moves ${shiftKey ? "backward" : "forward"} from programmatic focus with ${singleControl ? "one tabbable control" : "two tabbable controls"}`, async () => {
+        const { title, closeBtn, input, controller } = setup();
+        title.setAttribute("tabindex", "-1");
+        if (singleControl) input.remove();
+        try {
+          controller.open();
+          await waitForRaf();
+          expect(document.activeElement?.getAttribute("data-slot")).toBe("dialog-title");
+          const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey, bubbles: true, cancelable: true });
+          title.dispatchEvent(event);
+          expect(event.defaultPrevented).toBe(true);
+          expect(document.activeElement).toBe(shiftKey && !singleControl ? input : closeBtn);
+        } finally {
+          controller.destroy();
+        }
+      });
+    }
+  }
+
+  it("focuses the content when no eligible descendants remain", async () => {
+    const { content, controller } = setup();
+    content.innerHTML = '<summary>Not focusable</summary><button hidden>Hidden</button>';
+    try {
+      controller.open();
+      await waitForRaf();
+      expect(document.activeElement).toBe(content);
+      const event = new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true });
+      content.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(content);
+    } finally {
+      controller.destroy();
+    }
+  });
+
   beforeEach(() => {
     document.body.innerHTML = "";
   });

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -16,7 +16,7 @@ import {
   createDismissLayer,
   createPresenceLifecycle,
   focusElement,
-  getFocusable,
+  getAutofocusOrFirstFocusable,
   getTabbables,
 } from "@data-slot/core";
 
@@ -159,11 +159,8 @@ export function createDialog(
   };
 
   const focusFirst = () => {
-    const autofocusEl = getFocusable(content).find((element) => element.hasAttribute("autofocus"));
-    if (autofocusEl) return autofocusEl.focus();
-
-    const first = getFocusable(content)[0];
-    if (first) return first.focus();
+    const initialFocus = getAutofocusOrFirstFocusable(content);
+    if (initialFocus) return initialFocus.focus();
 
     ensureContentFocusable();
     content.focus();

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -317,10 +317,10 @@ export function createDialog(
     const last = focusables[focusables.length - 1]!;
     const active = content.ownerDocument.activeElement;
 
-    // If focus is outside the dialog, bring it back
-    if (!content.contains(active)) {
+    // Initial or programmatic focus may be inside the dialog but outside its tab order.
+    if (!focusables.includes(active as HTMLElement)) {
       e.preventDefault();
-      first.focus();
+      (e.shiftKey ? last : first).focus();
       return;
     }
 

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -16,6 +16,8 @@ import {
   createDismissLayer,
   createPresenceLifecycle,
   focusElement,
+  getFocusable,
+  getTabbables,
 } from "@data-slot/core";
 
 export interface DialogOptions {
@@ -55,10 +57,6 @@ export interface DialogController {
 const ROOT_BINDING_KEY = "@data-slot/dialog";
 const DUPLICATE_BINDING_WARNING =
   "[@data-slot/dialog] createDialog() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
-
-// Focusable element selector
-const FOCUSABLE =
-  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
 /**
  * Create a dialog controller for a root element
@@ -161,10 +159,10 @@ export function createDialog(
   };
 
   const focusFirst = () => {
-    const autofocusEl = content.querySelector<HTMLElement>("[autofocus]");
+    const autofocusEl = getFocusable(content).find((element) => element.hasAttribute("autofocus"));
     if (autofocusEl) return autofocusEl.focus();
 
-    const first = content.querySelector<HTMLElement>(FOCUSABLE);
+    const first = getFocusable(content)[0];
     if (first) return first.focus();
 
     ensureContentFocusable();
@@ -308,7 +306,7 @@ export function createDialog(
   const handleKeydown = (e: KeyboardEvent) => {
     if (e.key !== "Tab") return;
 
-    const focusables = content.querySelectorAll<HTMLElement>(FOCUSABLE);
+    const focusables = getTabbables(content);
 
     // If no focusables, prevent Tab from escaping
     if (focusables.length === 0) {
@@ -320,7 +318,7 @@ export function createDialog(
 
     const first = focusables[0]!;
     const last = focusables[focusables.length - 1]!;
-    const active = document.activeElement;
+    const active = content.ownerDocument.activeElement;
 
     // If focus is outside the dialog, bring it back
     if (!content.contains(active)) {

--- a/packages/navigation-menu/src/index.test.ts
+++ b/packages/navigation-menu/src/index.test.ts
@@ -3109,6 +3109,33 @@ describe("NavigationMenu", () => {
       return { root, triggers, contents, link1, link2, link3, controller };
     };
 
+    it("navigates only tabbable descendants and falls back to content when none remain", async () => {
+      const { triggers, contents, controller } = setupWithLinks();
+      const trigger = triggers[0]!;
+      const content = contents[0]!;
+      content.innerHTML = `
+        <h2 tabindex="-1">Programmatic only</h2>
+        <summary>Not focusable</summary>
+        <button hidden>Hidden</button>
+        <div style="visibility: hidden"><button id="visible-action" style="visibility: visible">Visible action</button></div>
+      `;
+      const action = content.querySelector<HTMLButtonElement>("#visible-action")!;
+      try {
+        controller.open("products");
+        trigger.focus();
+        trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+        await flushRAF();
+        expect(document.activeElement).toBe(action);
+        action.disabled = true;
+        trigger.focus();
+        trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+        await flushRAF();
+        expect(document.activeElement).toBe(content);
+      } finally {
+        controller.destroy();
+      }
+    });
+
     it("ArrowDown from trigger moves focus to first content element", async () => {
       const { triggers, link1, controller } = setupWithLinks();
 

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -9,6 +9,7 @@ import {
   hasRootBinding,
   setRootBinding,
   clearRootBinding,
+  getTabbables,
 } from "@data-slot/core";
 import { createPresenceLifecycle, setAria } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
@@ -335,26 +336,7 @@ export function createNavigationMenu(
     return discoveredItems.isNonSubmenuListTarget(target);
   };
 
-  // Focusable elements selector for content navigation
-  const focusableSelector =
-    'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
-
-  // Get focusable elements in a content panel
-  const getFocusableElements = (content: HTMLElement): HTMLElement[] => {
-    return Array.from(
-      content.querySelectorAll<HTMLElement>(focusableSelector),
-    ).filter((el) => !el.hidden && !el.closest("[hidden]"));
-  };
-
-  const isElementActuallyFocusable = (el: HTMLElement): boolean => {
-    if (!el.isConnected) return false;
-    if (el.hidden || el.closest("[hidden]")) return false;
-    if ("disabled" in el && (el as HTMLButtonElement).disabled) return false;
-    if (el.getAttribute("aria-hidden") === "true") return false;
-    if (el.getAttribute("tabindex") === "-1") return false;
-    if (el.matches(focusableSelector)) return true;
-    return el.tabIndex >= 0;
-  };
+  const getFocusableElements = getTabbables;
 
   const isWithinThisMenu = (candidate: HTMLElement): boolean => {
     if (root.contains(candidate)) return true;
@@ -377,9 +359,8 @@ export function createNavigationMenu(
 
   const focusNextFocusableAfterRoot = (): boolean => {
     const doc = root.ownerDocument;
-    const candidates = Array.from(doc.querySelectorAll<HTMLElement>("*"));
+    const candidates = getTabbables(doc);
     for (const candidate of candidates) {
-      if (!isElementActuallyFocusable(candidate)) continue;
       if (isWithinThisMenu(candidate)) continue;
       if (
         ((root as Node).compareDocumentPosition(candidate) &

--- a/packages/popover/src/index.test.ts
+++ b/packages/popover/src/index.test.ts
@@ -542,6 +542,28 @@ describe('Popover', () => {
 
   // Focus management tests
   describe('focus management', () => {
+    it('skips invalid autofocus targets and permits programmatic initial focus', async () => {
+      document.body.innerHTML = `
+        <div data-slot="popover" id="root">
+          <button data-slot="popover-trigger">Open</button>
+          <div data-slot="popover-content">
+            <summary autofocus>Not focusable</summary>
+            <button hidden autofocus>Hidden</button>
+            <h2 id="intro" tabindex="-1">Introduction</h2>
+            <button>Action</button>
+          </div>
+        </div>
+      `
+      const controller = createPopover(document.getElementById('root')!)
+      try {
+        controller.open()
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+        expect(document.activeElement).toBe(document.getElementById('intro'))
+      } finally {
+        controller.destroy()
+      }
+    })
+
     it('focuses first focusable element on open', () => {
       document.body.innerHTML = `
         <div data-slot="popover" id="root">

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -16,6 +16,7 @@ import {
   createPositionSync,
   createPortalLifecycle,
   createPresenceLifecycle,
+  getFocusable,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
@@ -30,10 +31,6 @@ const ALIGNS = ["start", "center", "end"] as const;
  * Kept for backward compatibility and planned for removal in the next major.
  */
 export type PopoverPosition = PopoverSide;
-
-// Focusable element selector
-const FOCUSABLE =
-  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
 export interface PopoverOptions {
   /** Initial open state */
@@ -209,10 +206,10 @@ export function createPopover(
 
   const focusFirst = () => {
     // Priority: [autofocus] > first focusable > content itself
-    const autofocusEl = content.querySelector<HTMLElement>("[autofocus]");
+    const autofocusEl = getFocusable(content).find((element) => element.hasAttribute("autofocus"));
     if (autofocusEl) return autofocusEl.focus();
 
-    const first = content.querySelector<HTMLElement>(FOCUSABLE);
+    const first = getFocusable(content)[0];
     if (first) return first.focus();
 
     // No focusable elements — make content itself focusable temporarily

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -16,7 +16,7 @@ import {
   createPositionSync,
   createPortalLifecycle,
   createPresenceLifecycle,
-  getFocusable,
+  getAutofocusOrFirstFocusable,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
@@ -206,11 +206,8 @@ export function createPopover(
 
   const focusFirst = () => {
     // Priority: [autofocus] > first focusable > content itself
-    const autofocusEl = getFocusable(content).find((element) => element.hasAttribute("autofocus"));
-    if (autofocusEl) return autofocusEl.focus();
-
-    const first = getFocusable(content)[0];
-    if (first) return first.focus();
+    const initialFocus = getAutofocusOrFirstFocusable(content);
+    if (initialFocus) return initialFocus.focus();
 
     // No focusable elements — make content itself focusable temporarily
     if (!content.getAttribute("tabindex")) {

--- a/packages/tabs/src/index.test.ts
+++ b/packages/tabs/src/index.test.ts
@@ -32,6 +32,25 @@ describe('Tabs', () => {
     return { root, list, triggers, panels, controller }
   }
 
+  it('ArrowDown selects a valid programmatic target and falls back to the panel', () => {
+    const { triggers, panels, controller } = setup()
+    const trigger = triggers[0]!
+    const panel = panels[0]!
+    panel.innerHTML = '<summary>Not focusable</summary><button hidden>Hidden</button><h2 tabindex="-1">Introduction</h2>'
+    const intro = panel.querySelector('h2')!
+    try {
+      trigger.focus()
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      expect(document.activeElement).toBe(intro)
+      intro.remove()
+      trigger.focus()
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+      expect(document.activeElement).toBe(panel)
+    } finally {
+      controller.destroy()
+    }
+  })
+
   it('initializes with first tab selected by default', () => {
     const { triggers, panels, controller } = setup()
 

--- a/packages/tabs/src/index.ts
+++ b/packages/tabs/src/index.ts
@@ -8,6 +8,7 @@ import {
   hasRootBinding,
   setRootBinding,
   clearRootBinding,
+  getFocusable,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, emit } from "@data-slot/core";
@@ -44,10 +45,6 @@ export interface TabsController {
 const ROOT_BINDING_KEY = "@data-slot/tabs";
 const DUPLICATE_BINDING_WARNING =
   "[@data-slot/tabs] createTabs() called more than once for the same root. Returning the existing controller. Destroy it before rebinding with new options.";
-
-// Focusable selector constant (shared with other components)
-const FOCUSABLE =
-  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
 interface TabItem {
   el: HTMLElement;
@@ -441,7 +438,7 @@ export function createTabs(
         const panel = item.panel;
         if (panel) {
           e.preventDefault();
-          const focusable = panel.querySelector<HTMLElement>(FOCUSABLE);
+          const focusable = getFocusable(panel)[0];
           (focusable || panel).focus();
           return;
         }


### PR DESCRIPTION
## Summary

Centralize focus discovery in `@data-slot/core` and use it across dialog, alert-dialog, popover, tabs, and navigation-menu. Opening a component now skips hidden, inert, and natively disabled targets; Tab navigation respects radio groups and the distinction between programmatic focus and keyboard tab stops.

Fix modal navigation when initial focus is on a `tabindex="-1"` heading: Tab and Shift+Tab now reach an eligible control instead of getting stuck. Preserve visible descendants of `visibility:hidden` ancestors, reject invalid summary and nested editable focus targets, and index checked radio groups once per DOM tree per discovery call.

## Reviewer guide

- Start with `packages/core/src/focus.ts` and its tests for eligibility and radio-group behavior.
- Check dialog and alert-dialog handling of focus outside their tabbable set, then the other component integrations.

## Validation

- `bun test`: 1,350 passed, including 18 new regression tests added after review.
- `bun run typecheck`: 143 existing diagnostics, identical to main after normalizing source line numbers; no new diagnostics.
- Chrome: verified focus eligibility, dialog and alert-dialog Tab navigation, popover/tabs/navigation-menu entry points and fallbacks using temporary browser fixtures.
- Real Tab presses reproduce the radio-boundary difference: main reaches the outside sentinel; this branch wraps to Cancel.
- A 100-radio fixture performs one whole-tree radio scan instead of 100.
- `git diff --check`: passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/data-slot/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791634957&installation_model_id=433409&pr_number=16&repository=bejamas%2Fdata-slot&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fdata-slot%2Fpull%2F16&signature=e5d3ea61fa88ec8aaa2a79c3a2d379549b515dca41951aca73a15ab6979e9697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
