### PR TITLE
fix(website): load alert dialog demo CSS

### DIFF
--- a/website/src/styles/demo.css
+++ b/website/src/styles/demo.css
@@ -275,6 +275,126 @@ html {
 }
 
 /* ============================================
+   CSS Example: Alert Dialog
+   ============================================ */
+.alert-dialog-trigger {
+  padding: 0.5rem 1rem;
+  background: #1a1a1a;
+  color: #faf9f7;
+  border: none;
+  cursor: pointer;
+}
+
+.alert-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.alert-dialog-overlay[data-open] {
+  opacity: 1;
+}
+
+.alert-dialog-overlay[data-starting-style],
+.alert-dialog-overlay[data-ending-style] {
+  opacity: 0;
+}
+
+.alert-dialog-panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.95);
+  background: #faf9f7;
+  padding: 2rem;
+  max-width: 400px;
+  width: calc(100% - 2rem);
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+  z-index: 101;
+  opacity: 0;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.alert-dialog-panel[data-open] {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.alert-dialog-panel[data-starting-style],
+.alert-dialog-panel[data-ending-style] {
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.95);
+}
+
+.alert-dialog-header {
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.alert-dialog-media {
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: #f0eeeb;
+  border: 1px solid #ccc;
+  color: #1a1a1a;
+  font-weight: 700;
+}
+
+.alert-dialog-title {
+  margin: 0;
+  font-weight: 700;
+}
+
+.alert-dialog-description {
+  margin: 0;
+  color: #666;
+  line-height: 1.5;
+}
+
+.alert-dialog-footer {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.5rem;
+}
+
+.alert-dialog-cancel,
+.alert-dialog-action {
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+}
+
+.alert-dialog-cancel {
+  background: none;
+  border: 1px solid #ccc;
+}
+
+.alert-dialog-action {
+  background: #1a1a1a;
+  color: #faf9f7;
+  border: none;
+}
+
+@media (min-width: 640px) {
+  .alert-dialog-footer {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+}
+
+/* ============================================
    CSS Example: Collapsible
    ============================================ */
 .collapsible-trigger-btn {


### PR DESCRIPTION
The plain CSS alert-dialog demo opens and locks scrolling, but its overlay and panel have no live styles. The CSS was only included in the highlighted source example when alert-dialog was introduced in 83c7b94, so the portaled panel renders after the page footer instead of as a modal.

Add those existing styles to the globally loaded demo stylesheet so Delete Project displays a centered confirmation dialog with a full-screen overlay and entry/exit transitions.

Validation:
- Browser verification during diagnosis: loading the same styles renders the overlay and centered panel; Cancel closes the dialog and restores scrolling. The Tailwind variant also works.
- Verified the added CSS matches the documented example, ignoring whitespace.
- Website production build passes (`bun run --cwd website astro build`).
- All 20 alert-dialog unit tests passed during diagnosis.
- `git diff --check` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/data-slot/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791704043&installation_model_id=433409&pr_number=18&repository=bejamas%2Fdata-slot&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fdata-slot%2Fpull%2F18&signature=a30489a3ddace1dc8135fbf9c568137105f440f9bf4b3522c8fb52085bcaa42e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->