### PR TITLE
fix: make floating and modal controller destruction terminal

### DIFF
--- a/packages/alert-dialog/README.md
+++ b/packages/alert-dialog/README.md
@@ -133,3 +133,13 @@ Events:
 - `aria-labelledby` / `aria-describedby` wiring from title and description
 - Focus is trapped while open
 - Focus returns to the trigger or previously focused element when closed
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.
+
+Destruction restores prior focus, falling back to a surviving trigger if the prior
+target was removed. Destroying an unopened modal does not move focus.

--- a/packages/alert-dialog/README.md
+++ b/packages/alert-dialog/README.md
@@ -134,8 +134,7 @@ Events:
 - Focus is trapped while open
 - Focus returns to the trigger or previously focused element when closed
 
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the

--- a/packages/alert-dialog/src/index.test.ts
+++ b/packages/alert-dialog/src/index.test.ts
@@ -121,6 +121,18 @@ describe("AlertDialog", () => {
     controller.destroy();
   });
 
+  it("keeps outside focus when destroyed before opening", async () => {
+    const { controller } = setup();
+    const outside = document.createElement("button");
+    document.body.prepend(outside);
+    outside.focus();
+
+    controller.destroy();
+    await waitForRaf();
+
+    expect(document.activeElement).toBe(outside);
+  });
+
   it("opens on trigger click and closes on cancel click", async () => {
     const { trigger, cancel, content, overlay, controller } = setup();
 

--- a/packages/alert-dialog/src/index.test.ts
+++ b/packages/alert-dialog/src/index.test.ts
@@ -406,4 +406,28 @@ describe("AlertDialog", () => {
 
     controller.destroy();
   });
+
+  it("keeps a retained controller inert, cancels queued focus, and releases scroll lock on destroy", async () => {
+    document.body.innerHTML = `
+      <button id="outside">Outside</button>
+      <div data-slot="alert-dialog" id="root">
+        <div data-slot="alert-dialog-overlay"></div>
+        <div data-slot="alert-dialog-content"><button id="inside">Inside</button></div>
+      </div>
+    `;
+    const outside = document.getElementById("outside") as HTMLButtonElement;
+    const root = document.getElementById("root")!;
+    const controller = createAlertDialog(root);
+
+    outside.focus();
+    controller.open();
+    expect(document.documentElement.style.overflow).toBe("hidden");
+    controller.destroy();
+    controller.open();
+    controller.destroy();
+
+    await waitForRaf();
+    expect(document.activeElement).toBe(outside);
+    expect(document.documentElement.style.overflow).toBe("");
+  });
 });

--- a/packages/alert-dialog/src/index.test.ts
+++ b/packages/alert-dialog/src/index.test.ts
@@ -421,6 +421,8 @@ describe("AlertDialog", () => {
 
     outside.focus();
     controller.open();
+    await waitForRaf();
+    expect(document.activeElement).toBe(document.getElementById("inside"));
     expect(document.documentElement.style.overflow).toBe("hidden");
     controller.destroy();
     controller.open();

--- a/packages/alert-dialog/src/index.test.ts
+++ b/packages/alert-dialog/src/index.test.ts
@@ -121,6 +121,23 @@ describe("AlertDialog", () => {
     controller.destroy();
   });
 
+  it("restores trigger focus on destroy when the original focus target was removed", async () => {
+    const { trigger, controller } = setup();
+    const outside = document.createElement("button");
+    document.body.prepend(outside);
+    outside.focus();
+    try {
+      controller.open();
+      await waitForRaf();
+      outside.remove();
+      controller.destroy();
+      await waitForRaf();
+      expect(document.activeElement).toBe(trigger);
+    } finally {
+      controller.destroy();
+    }
+  });
+
   it("keeps outside focus when destroyed before opening", async () => {
     const { controller } = setup();
     const outside = document.createElement("button");

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -86,7 +86,7 @@ export function createAlertDialog(
 
   let isOpen = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -99,8 +99,6 @@ export function createAlertDialog(
     terminalLifecycle.trackFinalRaf(() => {
       if (previousActiveElement && document.contains(previousActiveElement)) {
         focusElement(previousActiveElement);
-      } else if (trigger && document.contains(trigger)) {
-        focusElement(trigger);
       }
       previousActiveElement = null;
     });

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -364,7 +364,7 @@ export function createAlertDialog(
     get isOpen() {
       return isOpen;
     },
-    destroy: () => terminalLifecycle.destroy(),
+    destroy: () => { terminalLifecycle.destroy(); },
   };
 
   registerModalTerminalResources(terminalLifecycle, {

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -16,6 +16,7 @@ import {
   createDismissLayer,
   createPresenceLifecycle,
   createTerminalLifecycle,
+  drainCleanups,
   focusElement,
   getAutofocusOrFirstFocusable,
   getTabbables,
@@ -85,6 +86,7 @@ export function createAlertDialog(
 
   let isOpen = false;
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -386,8 +388,6 @@ export function createAlertDialog(
         didLockScroll = false;
       }
       cleanupContentFocusable();
-      cleanups.forEach((fn) => fn());
-      cleanups.length = 0;
 
       portalLifecycle?.cleanup();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -15,6 +15,7 @@ import {
   createModalStackItem,
   createDismissLayer,
   createPresenceLifecycle,
+  createTerminalLifecycle,
   focusElement,
   getAutofocusOrFirstFocusable,
   getTabbables,
@@ -84,6 +85,7 @@ export function createAlertDialog(
 
   let isOpen = false;
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -249,6 +251,7 @@ export function createAlertDialog(
   });
 
   const updateState = (open: boolean, force = false) => {
+    if (isDestroyed) return;
     if (isOpen === open && !force) return;
 
     if (open) {
@@ -343,13 +346,14 @@ export function createAlertDialog(
   );
 
   const controller: AlertDialogController = {
-    open: () => updateState(true),
-    close: () => updateState(false),
-    toggle: () => updateState(!isOpen),
+    open: () => { if (!isDestroyed) updateState(true); },
+    close: () => { if (!isDestroyed) updateState(false); },
+    toggle: () => { if (!isDestroyed) updateState(!isOpen); },
     get isOpen() {
       return isOpen;
     },
     destroy: () => {
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       modalStack.destroy();
       currentExitEpoch += 1;

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -93,6 +93,16 @@ export function createAlertDialog(
     : null;
 
   let didLockScroll = false;
+  terminalLifecycle.onBeforeDestroy(() => {
+    terminalLifecycle.trackFinalRaf(() => {
+      if (previousActiveElement && document.contains(previousActiveElement)) {
+        focusElement(previousActiveElement);
+      } else if (trigger && document.contains(trigger)) {
+        focusElement(trigger);
+      }
+      previousActiveElement = null;
+    });
+  });
   terminalLifecycle.onDestroy(() => {
     if (didLockScroll) {
       unlockScroll();
@@ -376,9 +386,6 @@ export function createAlertDialog(
         didLockScroll = false;
       }
       cleanupContentFocusable();
-      if (previousActiveElement !== null) {
-        restoreFocus();
-      }
       cleanups.forEach((fn) => fn());
       cleanups.length = 0;
 

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -84,7 +84,6 @@ export function createAlertDialog(
   }
 
   let isOpen = false;
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
@@ -183,7 +182,7 @@ export function createAlertDialog(
   let contentExitEpoch = 0;
 
   const finishClosePart = (element: HTMLElement, epoch: number) => {
-    if (isDestroyed || isOpen || epoch !== currentExitEpoch) return;
+    if (terminalLifecycle.isDestroyed || isOpen || epoch !== currentExitEpoch) return;
 
     element.hidden = true;
     pendingExitCount = Math.max(0, pendingExitCount - 1);
@@ -251,7 +250,7 @@ export function createAlertDialog(
   });
 
   const updateState = (open: boolean, force = false) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     if (isOpen === open && !force) return;
 
     if (open) {
@@ -300,7 +299,7 @@ export function createAlertDialog(
     onOpenChange?.(isOpen);
 
     if (open) {
-      requestAnimationFrame(focusFirst);
+      terminalLifecycle.trackRaf(() => focusFirst());
     }
   };
 
@@ -346,15 +345,14 @@ export function createAlertDialog(
   );
 
   const controller: AlertDialogController = {
-    open: () => { if (!isDestroyed) updateState(true); },
-    close: () => { if (!isDestroyed) updateState(false); },
-    toggle: () => { if (!isDestroyed) updateState(!isOpen); },
+    open: () => { if (!terminalLifecycle.isDestroyed) updateState(true); },
+    close: () => { if (!terminalLifecycle.isDestroyed) updateState(false); },
+    toggle: () => { if (!terminalLifecycle.isDestroyed) updateState(!isOpen); },
     get isOpen() {
       return isOpen;
     },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       modalStack.destroy();
       currentExitEpoch += 1;
       pendingExitCount = 0;

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -96,8 +96,12 @@ export function createAlertDialog(
   let didLockScroll = false;
   const restoreFocusOnDestroy = () => {
     terminalLifecycle.trackFinalRaf(() => {
-      if (previousActiveElement && document.contains(previousActiveElement)) {
-        focusElement(previousActiveElement);
+      if (previousActiveElement) {
+        if (document.contains(previousActiveElement)) {
+          focusElement(previousActiveElement);
+        } else if (trigger && document.contains(trigger)) {
+          focusElement(trigger);
+        }
       }
       previousActiveElement = null;
     });

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -16,7 +16,7 @@ import {
   createDismissLayer,
   createPresenceLifecycle,
   createTerminalLifecycle,
-  drainCleanups,
+  registerModalTerminalResources,
   focusElement,
   getAutofocusOrFirstFocusable,
   getTabbables,
@@ -86,7 +86,6 @@ export function createAlertDialog(
 
   let isOpen = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -95,20 +94,14 @@ export function createAlertDialog(
     : null;
 
   let didLockScroll = false;
-  terminalLifecycle.onBeforeDestroy(() => {
+  const restoreFocusOnDestroy = () => {
     terminalLifecycle.trackFinalRaf(() => {
       if (previousActiveElement && document.contains(previousActiveElement)) {
         focusElement(previousActiveElement);
       }
       previousActiveElement = null;
     });
-  });
-  terminalLifecycle.onDestroy(() => {
-    if (didLockScroll) {
-      unlockScroll();
-      didLockScroll = false;
-    }
-  });
+  };
 
   ensureId(content, "alert-dialog-content");
   content.setAttribute("role", "alertdialog");
@@ -367,13 +360,18 @@ export function createAlertDialog(
     get isOpen() {
       return isOpen;
     },
-    destroy: () => {
-      if (!terminalLifecycle.destroy()) return;
-      modalStack.destroy();
+    destroy: () => terminalLifecycle.destroy(),
+  };
+
+  registerModalTerminalResources(terminalLifecycle, {
+    cleanups,
+    modalStack,
+    presence: [overlayPresence, contentPresence],
+    portal: portalLifecycle,
+    beforeDestroy: restoreFocusOnDestroy,
+    reset: () => {
       currentExitEpoch += 1;
       pendingExitCount = 0;
-      overlayPresence.cleanup();
-      contentPresence.cleanup();
       isOpen = false;
       setDataState("closed");
       overlay.hidden = true;
@@ -381,16 +379,16 @@ export function createAlertDialog(
       if (trigger) {
         setAria(trigger, "expanded", false);
       }
+    },
+    releaseScrollLock: () => {
       if (didLockScroll) {
         unlockScroll();
         didLockScroll = false;
       }
-      cleanupContentFocusable();
-
-      portalLifecycle?.cleanup();
-      clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
-  };
+    cleanup: cleanupContentFocusable,
+    unbind: () => clearRootBinding(root, ROOT_BINDING_KEY, controller),
+  });
 
   cleanups.push(
     onRoot(root, "alert-dialog:set", (e) => {

--- a/packages/alert-dialog/src/index.ts
+++ b/packages/alert-dialog/src/index.ts
@@ -93,6 +93,12 @@ export function createAlertDialog(
     : null;
 
   let didLockScroll = false;
+  terminalLifecycle.onDestroy(() => {
+    if (didLockScroll) {
+      unlockScroll();
+      didLockScroll = false;
+    }
+  });
 
   ensureId(content, "alert-dialog-content");
   content.setAttribute("role", "alertdialog");
@@ -134,7 +140,7 @@ export function createAlertDialog(
   };
 
   const restoreFocus = () => {
-    requestAnimationFrame(() => {
+    terminalLifecycle.trackRaf(() => {
       if (
         previousActiveElement &&
         document.contains(previousActiveElement) &&

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -318,13 +318,12 @@ emitting a value-change event. An open popup also resets its search and highligh
 Synchronization happens on the next event-loop task, after the browser resets
 native controls. Calling `preventDefault()` on the reset event preserves the current state.
 
-## License
-
-MIT
-
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the
 old controller become no-ops. Create a new controller on the same root to rebind it.
+
+## License
+
+MIT

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -321,3 +321,10 @@ native controls. Calling `preventDefault()` on the reset event preserves the cur
 ## License
 
 MIT
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -131,7 +131,6 @@ export function createCombobox(
     container: authoredPositioner ?? undefined,
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
 
   const matchesMediaQuery = (query: string): boolean => {
@@ -340,7 +339,7 @@ export function createCombobox(
   const presence = createPresenceLifecycle({
     element: content,
     onExitComplete: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       portal.restore();
       content.hidden = true;
     },
@@ -363,7 +362,7 @@ export function createCombobox(
   };
 
   const updateOpenState = (open: boolean, skipFocusRestore = false) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     if (isOpen === open) return;
     if (disabled && open) return;
 
@@ -383,8 +382,8 @@ export function createCombobox(
       updatePosition();
       positionSync.update();
 
-      requestAnimationFrame(() => {
-        if (!isOpen) return;
+      terminalLifecycle.trackRaf(() => {
+        if (terminalLifecycle.isDestroyed || !isOpen) return;
         positionSync.update();
       });
     } else {
@@ -769,19 +768,18 @@ export function createCombobox(
     get value() { return currentValue; },
     get inputValue() { return input.value; },
     get isOpen() { return isOpen; },
-    select: (value: string) => { if (!isDestroyed) updateValue(value); },
-    clear: () => { if (!isDestroyed) updateValue(null); },
-    open: () => { if (!isDestroyed) updateOpenState(true); },
-    close: () => { if (!isDestroyed) updateOpenState(false); },
+    select: (value: string) => { if (!terminalLifecycle.isDestroyed) updateValue(value); },
+    clear: () => { if (!terminalLifecycle.isDestroyed) updateValue(null); },
+    open: () => { if (!terminalLifecycle.isDestroyed) updateOpenState(true); },
+    close: () => { if (!terminalLifecycle.isDestroyed) updateOpenState(false); },
     setItemToStringValue: (nextItemToStringValue: ComboboxItemToStringValue | null) => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       itemToStringValue = nextItemToStringValue;
       collection.setItemToStringValue(itemToStringValue);
       updateValue(currentValue, true);
     },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       isOpen = false;
       setAria(input, "expanded", false);
       setDataState("closed");

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -17,7 +17,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
-  drainCleanups,
+  registerFloatingTerminalResources,
   createDismissLayer,
   createFormFieldAdapter,
 } from "@data-slot/core";
@@ -133,7 +133,6 @@ export function createCombobox(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
 
   const matchesMediaQuery = (query: string): boolean => {
     if (typeof win.matchMedia !== "function") return false;
@@ -785,14 +784,18 @@ export function createCombobox(
       isOpen = false;
       setAria(input, "expanded", false);
       setDataState("closed");
-      positionSync.stop();
-      presence.cleanup();
-      portal.cleanup();
       content.hidden = true;
       formField?.destroy();
-      clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };
+
+  registerFloatingTerminalResources(terminalLifecycle, {
+    cleanups,
+    positionSync,
+    presence,
+    portal,
+    unbind: () => clearRootBinding(root, ROOT_BINDING_KEY, controller),
+  });
 
   setRootBinding(root, ROOT_BINDING_KEY, controller);
   if (defaultOpen) updateOpenState(true);

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -17,6 +17,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
+  drainCleanups,
   createDismissLayer,
   createFormFieldAdapter,
 } from "@data-slot/core";
@@ -132,6 +133,7 @@ export function createCombobox(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
 
   const matchesMediaQuery = (query: string): boolean => {
     if (typeof win.matchMedia !== "function") return false;
@@ -787,8 +789,6 @@ export function createCombobox(
       presence.cleanup();
       portal.cleanup();
       content.hidden = true;
-      cleanups.forEach((fn) => fn());
-      cleanups.length = 0;
       formField?.destroy();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -133,7 +133,7 @@ export function createCombobox(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
 
   const matchesMediaQuery = (query: string): boolean => {
     if (typeof win.matchMedia !== "function") return false;

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -776,10 +776,15 @@ export function createCombobox(
       updateValue(currentValue, true);
     },
     destroy: () => {
+      if (isDestroyed) return;
       isDestroyed = true;
+      isOpen = false;
+      setAria(input, "expanded", false);
+      setDataState("closed");
       positionSync.stop();
       presence.cleanup();
       portal.cleanup();
+      content.hidden = true;
       cleanups.forEach((fn) => fn());
       cleanups.length = 0;
       formField?.destroy();

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -361,6 +361,7 @@ export function createCombobox(
   };
 
   const updateOpenState = (open: boolean, skipFocusRestore = false) => {
+    if (isDestroyed) return;
     if (isOpen === open) return;
     if (disabled && open) return;
 
@@ -766,11 +767,12 @@ export function createCombobox(
     get value() { return currentValue; },
     get inputValue() { return input.value; },
     get isOpen() { return isOpen; },
-    select: (value: string) => updateValue(value),
-    clear: () => updateValue(null),
-    open: () => updateOpenState(true),
-    close: () => updateOpenState(false),
+    select: (value: string) => { if (!isDestroyed) updateValue(value); },
+    clear: () => { if (!isDestroyed) updateValue(null); },
+    open: () => { if (!isDestroyed) updateOpenState(true); },
+    close: () => { if (!isDestroyed) updateOpenState(false); },
     setItemToStringValue: (nextItemToStringValue: ComboboxItemToStringValue | null) => {
+      if (isDestroyed) return;
       itemToStringValue = nextItemToStringValue;
       collection.setItemToStringValue(itemToStringValue);
       updateValue(currentValue, true);

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -16,6 +16,7 @@ import {
   createPositionSync,
   createPortalLifecycle,
   createPresenceLifecycle,
+  createTerminalLifecycle,
   createDismissLayer,
   createFormFieldAdapter,
 } from "@data-slot/core";
@@ -131,6 +132,7 @@ export function createCombobox(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
 
   const matchesMediaQuery = (query: string): boolean => {
     if (typeof win.matchMedia !== "function") return false;
@@ -778,7 +780,7 @@ export function createCombobox(
       updateValue(currentValue, true);
     },
     destroy: () => {
-      if (isDestroyed) return;
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       isOpen = false;
       setAria(input, "expanded", false);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -142,11 +142,7 @@ function createCustomComponent(root: Element) {
 }
 ```
 
-## License
-
-MIT
-
-### Terminal lifecycle
+## Terminal lifecycle
 
 `createTerminalLifecycle()` manages work that must stop permanently when a
 controller is destroyed. It returns a `TerminalLifecycleController`:
@@ -187,3 +183,7 @@ and interaction events remain the component's responsibility.
 `drainCleanups(cleanups)` removes the current callbacks from an array and invokes
 them in order. Repeating the call on the emptied array does nothing. Cleanup
 callbacks should complete synchronously without throwing.
+
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -145,3 +145,45 @@ function createCustomComponent(root: Element) {
 ## License
 
 MIT
+
+### Terminal lifecycle
+
+`createTerminalLifecycle()` manages work that must stop permanently when a
+controller is destroyed. It returns a `TerminalLifecycleController`:
+
+| Member | Behavior |
+| --- | --- |
+| `isDestroyed` | Becomes `true` after the before-destroy hooks and before resource cleanup. |
+| `trackRaf(callback)` | Schedules an animation frame; returns its handle or `null` once destruction starts. |
+| `trackTimeout(callback, delay)` | Schedules a timeout; returns its handle or `null` once destruction starts. |
+| `cancelRaf(handle)` / `cancelTimeout(handle)` | Cancel tracked work and immediately release its handle. Null, finished, or already-canceled handles are ignored. Use these methods instead of native cancellation for tracked work. |
+| `onBeforeDestroy(callback)` | Registers synchronous preparation after ordinary pending work is canceled, before resource cleanup. |
+| `trackFinalRaf(callback)` | Schedules a final frame only from a before-destroy hook. This frame deliberately survives destruction, for example to finish an already-pending focus restoration. Returns `null` outside that phase. |
+| `onDestroy(callback)` | Registers synchronous resource cleanup, or runs it immediately if already destroyed. |
+| `destroy()` | Cancels pending work and runs hooks once. Returns `true` for the first destruction, `false` for repeated or reentrant calls. |
+
+```typescript
+import { createTerminalLifecycle } from "@data-slot/core";
+
+const lifecycle = createTerminalLifecycle();
+const frame = lifecycle.trackRaf(() => updatePosition());
+lifecycle.cancelRaf(frame);
+lifecycle.onDestroy(() => observer.disconnect());
+lifecycle.destroy();
+```
+
+`registerFloatingTerminalResources(lifecycle, resources)` registers cleanup for
+`positionSync`, `presence`, `portal`, a `cleanups` array, and an `unbind` callback,
+in that order. The resources use the exported `FloatingTerminalResources` type.
+The component remains responsible for its closed state and focus policy.
+
+`registerModalTerminalResources(lifecycle, resources)` optionally registers a
+`beforeDestroy` hook, then disposes `modalStack`, each entry in the `presence`
+array, calls `reset`, `releaseScrollLock`, and `cleanup`, cleans up the nullable
+`portal`, drains listener `cleanups`, and calls `unbind`, in that order.
+`ModalTerminalResources` describes these callbacks and resources. Focus policy
+and interaction events remain the component's responsibility.
+
+`drainCleanups(cleanups)` removes the current callbacks from an array and invokes
+them in order. Repeating the call on the emptied array does nothing. Cleanup
+callbacks should complete synchronously without throwing.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -32,6 +32,8 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createPositionSync,
+  createTerminalLifecycle,
+  registerModalTerminalResources,
 } from './index'
 import type { PortalState } from './index'
 import { getScrollLockCount, resetScrollLock } from './scroll'
@@ -148,6 +150,42 @@ describe('core/focusability', () => {
     `
 
     expect(getAutofocusOrFirstFocusable(document.getElementById('root')!)?.id).toBe('autofocus')
+  })
+})
+
+describe('core/modal terminal resources', () => {
+  it('disposes modal resources in a stable terminal order', () => {
+    const calls: string[] = []
+    const lifecycle = createTerminalLifecycle()
+
+    registerModalTerminalResources(lifecycle, {
+      cleanups: [() => calls.push('listener')],
+      modalStack: { destroy: () => calls.push('modal stack') },
+      presence: [
+        { cleanup: () => calls.push('overlay presence') },
+        { cleanup: () => calls.push('content presence') },
+      ],
+      portal: { cleanup: () => calls.push('portal') },
+      beforeDestroy: () => calls.push('before destroy'),
+      reset: () => calls.push('reset'),
+      releaseScrollLock: () => calls.push('scroll lock'),
+      cleanup: () => calls.push('component cleanup'),
+      unbind: () => calls.push('root unbind'),
+    })
+
+    expect(lifecycle.destroy()).toBe(true)
+    expect(calls).toEqual([
+      'before destroy',
+      'modal stack',
+      'overlay presence',
+      'content presence',
+      'reset',
+      'scroll lock',
+      'component cleanup',
+      'portal',
+      'listener',
+      'root unbind',
+    ])
   })
 })
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export {
   createModalStackItem,
   createDismissLayer,
   createPortalLifecycle,
+  createTerminalLifecycle,
   createPresenceLifecycle,
   createPositionSync,
 } from "./popup.ts";
@@ -53,6 +54,7 @@ export type {
   DismissLayerOptions,
   PortalLifecycleOptions,
   PortalLifecycleController,
+  TerminalLifecycleController,
   PresenceLifecycleOptions,
   PresenceLifecycleController,
 } from "./popup.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ export {
   createPortalLifecycle,
   createTerminalLifecycle,
   drainCleanups,
+  registerFloatingTerminalResources,
   createPresenceLifecycle,
   createPositionSync,
 } from "./popup.ts";
@@ -56,6 +57,7 @@ export type {
   PortalLifecycleOptions,
   PortalLifecycleController,
   TerminalLifecycleController,
+  FloatingTerminalResources,
   PresenceLifecycleOptions,
   PresenceLifecycleController,
 } from "./popup.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export {
   createDismissLayer,
   createPortalLifecycle,
   createTerminalLifecycle,
+  drainCleanups,
   createPresenceLifecycle,
   createPositionSync,
 } from "./popup.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export {
   createTerminalLifecycle,
   drainCleanups,
   registerFloatingTerminalResources,
+  registerModalTerminalResources,
   createPresenceLifecycle,
   createPositionSync,
 } from "./popup.ts";
@@ -58,6 +59,7 @@ export type {
   PortalLifecycleController,
   TerminalLifecycleController,
   FloatingTerminalResources,
+  ModalTerminalResources,
   PresenceLifecycleOptions,
   PresenceLifecycleController,
 } from "./popup.ts";

--- a/packages/core/src/popup.ts
+++ b/packages/core/src/popup.ts
@@ -539,6 +539,30 @@ export interface PortalLifecycleController {
   cleanup(): void;
 }
 
+/**
+ * Shared terminal gate for controllers whose DOM and asynchronous work must
+ * become permanently inert after destroy().
+ */
+export interface TerminalLifecycleController {
+  readonly isDestroyed: boolean;
+  /** Returns false when destruction has already run. */
+  destroy(): boolean;
+}
+
+export function createTerminalLifecycle(): TerminalLifecycleController {
+  let isDestroyed = false;
+  return {
+    get isDestroyed() {
+      return isDestroyed;
+    },
+    destroy() {
+      if (isDestroyed) return false;
+      isDestroyed = true;
+      return true;
+    },
+  };
+}
+
 export function createPortalLifecycle(options: PortalLifecycleOptions): PortalLifecycleController {
   const enabled = options.enabled ?? true;
   const wrapperSlot = options.wrapperSlot;

--- a/packages/core/src/popup.ts
+++ b/packages/core/src/popup.ts
@@ -600,7 +600,7 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
       return requestAnimationFrame(callback);
     },
     trackTimeout: (callback, delay) => {
-      if (isDestroyed) return null;
+      if (isDestroyed || isDestroying) return null;
       const handle = setTimeout(() => {
         timeouts.delete(handle);
         if (!isDestroyed) callback();

--- a/packages/core/src/popup.ts
+++ b/packages/core/src/popup.ts
@@ -1,6 +1,7 @@
 import { on } from "./events.ts";
 import { containsWithPortals, portalToBody, restorePortal } from "./parts.ts";
 import type { PortalState } from "./parts.ts";
+import type { ModalStackItemController } from "./popup-geometry";
 
 export * from "./popup-geometry";
 
@@ -629,6 +630,40 @@ export function registerFloatingTerminalResources(
     resources.positionSync.stop();
     resources.presence.cleanup();
     resources.portal.cleanup();
+    drainCleanups(resources.cleanups);
+    resources.unbind();
+  });
+}
+
+export interface ModalTerminalResources {
+  cleanups: Array<() => void>;
+  modalStack: Pick<ModalStackItemController, "destroy">;
+  presence: Array<Pick<PresenceLifecycleController, "cleanup">>;
+  portal: Pick<PortalLifecycleController, "cleanup"> | null;
+  beforeDestroy?: () => void;
+  reset: () => void;
+  releaseScrollLock: () => void;
+  cleanup: () => void;
+  unbind: () => void;
+}
+
+/**
+ * Registers the terminal disposal order shared by modal controls. Behavioral
+ * policy (events, dismissal, roles, and focus target selection) stays in the
+ * component; this owns only the resource disposal sequence.
+ */
+export function registerModalTerminalResources(
+  lifecycle: TerminalLifecycleController,
+  resources: ModalTerminalResources,
+): void {
+  if (resources.beforeDestroy) lifecycle.onBeforeDestroy(resources.beforeDestroy);
+  lifecycle.onDestroy(() => {
+    resources.modalStack.destroy();
+    for (const presence of resources.presence) presence.cleanup();
+    resources.reset();
+    resources.releaseScrollLock();
+    resources.cleanup();
+    resources.portal?.cleanup();
     drainCleanups(resources.cleanups);
     resources.unbind();
   });

--- a/packages/core/src/popup.ts
+++ b/packages/core/src/popup.ts
@@ -547,6 +547,7 @@ export interface TerminalLifecycleController {
   readonly isDestroyed: boolean;
   onBeforeDestroy(callback: () => void): void;
   onDestroy(callback: () => void): void;
+  onDestroyBundle(callbacks: readonly (() => void)[]): void;
   trackRaf(callback: FrameRequestCallback): number | null;
   trackFinalRaf(callback: FrameRequestCallback): number | null;
   trackTimeout(callback: () => void, delay: number): ReturnType<typeof setTimeout> | null;
@@ -572,6 +573,15 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
     onDestroy: (callback) => {
       if (isDestroyed) callback();
       else teardowns.push(callback);
+    },
+    onDestroyBundle: (callbacks) => {
+      if (isDestroyed) {
+        for (const callback of callbacks) callback();
+        return;
+      }
+      teardowns.push(() => {
+        for (const callback of callbacks) callback();
+      });
     },
     trackRaf: (callback) => {
       if (isDestroyed || isDestroying) return null;
@@ -610,6 +620,11 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
       return true;
     },
   };
+}
+
+/** Run a component's listener cleanup collection exactly once. */
+export function drainCleanups(cleanups: Array<() => void>): void {
+  for (const cleanup of cleanups.splice(0)) cleanup();
 }
 
 export function createPortalLifecycle(options: PortalLifecycleOptions): PortalLifecycleController {

--- a/packages/core/src/popup.ts
+++ b/packages/core/src/popup.ts
@@ -547,7 +547,6 @@ export interface TerminalLifecycleController {
   readonly isDestroyed: boolean;
   onBeforeDestroy(callback: () => void): void;
   onDestroy(callback: () => void): void;
-  onDestroyBundle(callbacks: readonly (() => void)[]): void;
   trackRaf(callback: FrameRequestCallback): number | null;
   trackFinalRaf(callback: FrameRequestCallback): number | null;
   trackTimeout(callback: () => void, delay: number): ReturnType<typeof setTimeout> | null;
@@ -573,15 +572,6 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
     onDestroy: (callback) => {
       if (isDestroyed) callback();
       else teardowns.push(callback);
-    },
-    onDestroyBundle: (callbacks) => {
-      if (isDestroyed) {
-        for (const callback of callbacks) callback();
-        return;
-      }
-      teardowns.push(() => {
-        for (const callback of callbacks) callback();
-      });
     },
     trackRaf: (callback) => {
       if (isDestroyed || isDestroying) return null;
@@ -620,6 +610,28 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
       return true;
     },
   };
+}
+
+export interface FloatingTerminalResources {
+  cleanups: Array<() => void>;
+  positionSync: Pick<PositionSyncController, "stop">;
+  presence: Pick<PresenceLifecycleController, "cleanup">;
+  portal: Pick<PortalLifecycleController, "cleanup">;
+  unbind: () => void;
+}
+
+/** Registers the mechanical terminal disposal order shared by floating controls. */
+export function registerFloatingTerminalResources(
+  lifecycle: TerminalLifecycleController,
+  resources: FloatingTerminalResources,
+): void {
+  lifecycle.onDestroy(() => {
+    resources.positionSync.stop();
+    resources.presence.cleanup();
+    resources.portal.cleanup();
+    drainCleanups(resources.cleanups);
+    resources.unbind();
+  });
 }
 
 /** Run a component's listener cleanup collection exactly once. */

--- a/packages/core/src/popup.ts
+++ b/packages/core/src/popup.ts
@@ -549,6 +549,9 @@ export interface TerminalLifecycleController {
   onBeforeDestroy(callback: () => void): void;
   onDestroy(callback: () => void): void;
   trackRaf(callback: FrameRequestCallback): number | null;
+  /** Cancel tracked work and release its handle immediately. */
+  cancelRaf(handle: number | null): void;
+  cancelTimeout(handle: ReturnType<typeof setTimeout> | null): void;
   trackFinalRaf(callback: FrameRequestCallback): number | null;
   trackTimeout(callback: () => void, delay: number): ReturnType<typeof setTimeout> | null;
   destroy(): boolean;
@@ -583,6 +586,14 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
       });
       rafs.add(handle);
       return handle;
+    },
+    cancelRaf: (handle) => {
+      if (handle === null || !rafs.delete(handle)) return;
+      cancelAnimationFrame(handle);
+    },
+    cancelTimeout: (handle) => {
+      if (handle === null || !timeouts.delete(handle)) return;
+      clearTimeout(handle);
     },
     trackFinalRaf: (callback) => {
       if (!isDestroying || isDestroyed) return null;

--- a/packages/core/src/popup.ts
+++ b/packages/core/src/popup.ts
@@ -545,15 +545,18 @@ export interface PortalLifecycleController {
  */
 export interface TerminalLifecycleController {
   readonly isDestroyed: boolean;
-  guard<T extends unknown[]>(callback: (...args: T) => void): (...args: T) => void;
+  onBeforeDestroy(callback: () => void): void;
   onDestroy(callback: () => void): void;
   trackRaf(callback: FrameRequestCallback): number | null;
+  trackFinalRaf(callback: FrameRequestCallback): number | null;
   trackTimeout(callback: () => void, delay: number): ReturnType<typeof setTimeout> | null;
   destroy(): boolean;
 }
 
 export function createTerminalLifecycle(): TerminalLifecycleController {
   let isDestroyed = false;
+  let isDestroying = false;
+  const beforeTeardowns: Array<() => void> = [];
   const teardowns: Array<() => void> = [];
   const rafs = new Set<number>();
   const timeouts = new Set<ReturnType<typeof setTimeout>>();
@@ -561,15 +564,17 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
     get isDestroyed() {
       return isDestroyed;
     },
-    guard: (callback) => (...args) => {
-      if (!isDestroyed) callback(...args);
+    onBeforeDestroy: (callback) => {
+      if (isDestroyed) return;
+      if (isDestroying) callback();
+      else beforeTeardowns.push(callback);
     },
     onDestroy: (callback) => {
       if (isDestroyed) callback();
       else teardowns.push(callback);
     },
     trackRaf: (callback) => {
-      if (isDestroyed) return null;
+      if (isDestroyed || isDestroying) return null;
       let handle = 0;
       handle = requestAnimationFrame((time) => {
         rafs.delete(handle);
@@ -577,6 +582,10 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
       });
       rafs.add(handle);
       return handle;
+    },
+    trackFinalRaf: (callback) => {
+      if (!isDestroying || isDestroyed) return null;
+      return requestAnimationFrame(callback);
     },
     trackTimeout: (callback, delay) => {
       if (isDestroyed) return null;
@@ -588,12 +597,15 @@ export function createTerminalLifecycle(): TerminalLifecycleController {
       return handle;
     },
     destroy() {
-      if (isDestroyed) return false;
-      isDestroyed = true;
+      if (isDestroyed || isDestroying) return false;
+      isDestroying = true;
       for (const handle of rafs) cancelAnimationFrame(handle);
       rafs.clear();
       for (const handle of timeouts) clearTimeout(handle);
       timeouts.clear();
+      for (const teardown of beforeTeardowns.splice(0)) teardown();
+      isDestroyed = true;
+      isDestroying = false;
       for (const teardown of teardowns.splice(0)) teardown();
       return true;
     },

--- a/packages/core/src/popup.ts
+++ b/packages/core/src/popup.ts
@@ -545,19 +545,56 @@ export interface PortalLifecycleController {
  */
 export interface TerminalLifecycleController {
   readonly isDestroyed: boolean;
-  /** Returns false when destruction has already run. */
+  guard<T extends unknown[]>(callback: (...args: T) => void): (...args: T) => void;
+  onDestroy(callback: () => void): void;
+  trackRaf(callback: FrameRequestCallback): number | null;
+  trackTimeout(callback: () => void, delay: number): ReturnType<typeof setTimeout> | null;
   destroy(): boolean;
 }
 
 export function createTerminalLifecycle(): TerminalLifecycleController {
   let isDestroyed = false;
+  const teardowns: Array<() => void> = [];
+  const rafs = new Set<number>();
+  const timeouts = new Set<ReturnType<typeof setTimeout>>();
   return {
     get isDestroyed() {
       return isDestroyed;
     },
+    guard: (callback) => (...args) => {
+      if (!isDestroyed) callback(...args);
+    },
+    onDestroy: (callback) => {
+      if (isDestroyed) callback();
+      else teardowns.push(callback);
+    },
+    trackRaf: (callback) => {
+      if (isDestroyed) return null;
+      let handle = 0;
+      handle = requestAnimationFrame((time) => {
+        rafs.delete(handle);
+        if (!isDestroyed) callback(time);
+      });
+      rafs.add(handle);
+      return handle;
+    },
+    trackTimeout: (callback, delay) => {
+      if (isDestroyed) return null;
+      const handle = setTimeout(() => {
+        timeouts.delete(handle);
+        if (!isDestroyed) callback();
+      }, delay);
+      timeouts.add(handle);
+      return handle;
+    },
     destroy() {
       if (isDestroyed) return false;
       isDestroyed = true;
+      for (const handle of rafs) cancelAnimationFrame(handle);
+      rafs.clear();
+      for (const handle of timeouts) clearTimeout(handle);
+      timeouts.clear();
+      for (const teardown of teardowns.splice(0)) teardown();
       return true;
     },
   };

--- a/packages/core/src/terminal-lifecycle.test.ts
+++ b/packages/core/src/terminal-lifecycle.test.ts
@@ -59,3 +59,23 @@ it("does not run canceled callbacks while allowing other work to finish", async 
     lifecycle.destroy();
   }
 });
+
+
+it("rejects normal asynchronous work during before-destroy callbacks", () => {
+  const lifecycle = createTerminalLifecycle();
+  const scheduleTimeout = spyOn(globalThis, "setTimeout");
+  const scheduleRaf = spyOn(globalThis, "requestAnimationFrame");
+  try {
+    lifecycle.onBeforeDestroy(() => {
+      expect(lifecycle.trackTimeout(() => {}, 60_000)).toBeNull();
+      expect(lifecycle.trackRaf(() => {})).toBeNull();
+    });
+    lifecycle.destroy();
+    expect(scheduleTimeout).not.toHaveBeenCalled();
+    expect(scheduleRaf).not.toHaveBeenCalled();
+  } finally {
+    lifecycle.destroy();
+    scheduleTimeout.mockRestore();
+    scheduleRaf.mockRestore();
+  }
+});

--- a/packages/core/src/terminal-lifecycle.test.ts
+++ b/packages/core/src/terminal-lifecycle.test.ts
@@ -1,0 +1,61 @@
+import { expect, it, spyOn } from "bun:test";
+import { createTerminalLifecycle } from "./popup";
+
+it("forgets canceled work and only cancels outstanding work on destroy", () => {
+  const cancelRaf = spyOn(globalThis, "cancelAnimationFrame");
+  const cancelTimeout = spyOn(globalThis, "clearTimeout");
+  const lifecycle = createTerminalLifecycle();
+  try {
+    for (let i = 0; i < 100; i++) {
+      const frame = lifecycle.trackRaf(() => {});
+      const timer = lifecycle.trackTimeout(() => {}, 60_000);
+      lifecycle.cancelRaf(frame);
+      lifecycle.cancelTimeout(timer);
+      lifecycle.cancelRaf(frame);
+      lifecycle.cancelTimeout(timer);
+    }
+    expect(cancelRaf).toHaveBeenCalledTimes(100);
+    expect(cancelTimeout).toHaveBeenCalledTimes(100);
+    cancelRaf.mockClear();
+    cancelTimeout.mockClear();
+
+    const pendingFrame = lifecycle.trackRaf(() => {});
+    const pendingTimer = lifecycle.trackTimeout(() => {}, 60_000);
+    lifecycle.destroy();
+    expect(cancelRaf).toHaveBeenCalledTimes(1);
+    expect(cancelRaf).toHaveBeenCalledWith(pendingFrame);
+    expect(cancelTimeout).toHaveBeenCalledTimes(1);
+    expect(cancelTimeout).toHaveBeenCalledWith(pendingTimer);
+    lifecycle.cancelRaf(null);
+    lifecycle.cancelTimeout(null);
+    lifecycle.destroy();
+    expect(cancelRaf).toHaveBeenCalledTimes(1);
+    expect(cancelTimeout).toHaveBeenCalledTimes(1);
+  } finally {
+    lifecycle.destroy();
+    cancelRaf.mockRestore();
+    cancelTimeout.mockRestore();
+  }
+});
+
+it("does not run canceled callbacks while allowing other work to finish", async () => {
+  const lifecycle = createTerminalLifecycle();
+  const calls: string[] = [];
+  try {
+    lifecycle.cancelRaf(lifecycle.trackRaf(() => calls.push("canceled frame")));
+    lifecycle.cancelTimeout(lifecycle.trackTimeout(() => calls.push("canceled timer"), 0));
+    await Promise.all([
+      new Promise<void>((resolve) => lifecycle.trackRaf(() => {
+        calls.push("frame");
+        resolve();
+      })),
+      new Promise<void>((resolve) => lifecycle.trackTimeout(() => {
+        calls.push("timer");
+        resolve();
+      }, 0)),
+    ]);
+    expect(calls.sort()).toEqual(["frame", "timer"]);
+  } finally {
+    lifecycle.destroy();
+  }
+});

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -267,3 +267,13 @@ Use `{ open: boolean }` instead.
 ## License
 
 MIT
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.
+
+Destruction restores prior focus, falling back to a surviving trigger if the prior
+target was removed. Destroying an unopened modal does not move focus.

--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -264,12 +264,7 @@ element.dispatchEvent(
 
 Use `{ open: boolean }` instead.
 
-## License
-
-MIT
-
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the
@@ -277,3 +272,7 @@ old controller become no-ops. Create a new controller on the same root to rebind
 
 Destruction restores prior focus, falling back to a surviving trigger if the prior
 target was removed. Destroying an unopened modal does not move focus.
+
+## License
+
+MIT

--- a/packages/dialog/src/index.test.ts
+++ b/packages/dialog/src/index.test.ts
@@ -1027,6 +1027,28 @@ describe("Dialog", () => {
     });
   });
 
+  it("keeps a retained controller inert and cancels queued focus after destroy", async () => {
+    document.body.innerHTML = `
+      <button id="outside">Outside</button>
+      <div data-slot="dialog" id="root">
+        <div data-slot="dialog-overlay"></div>
+        <div data-slot="dialog-content"><button>Inside</button></div>
+      </div>
+    `;
+    const outside = document.getElementById("outside") as HTMLButtonElement;
+    const controller = createDialog(document.getElementById("root")!);
+
+    outside.focus();
+    controller.open();
+    controller.destroy();
+    controller.open();
+    controller.destroy();
+
+    await waitForRaf();
+    expect(document.activeElement).toBe(outside);
+    expect(controller.isOpen).toBe(false);
+  });
+
   // Data attribute tests
   describe("data attributes", () => {
     it("data-close-on-escape='false' disables Escape key closing", () => {

--- a/packages/dialog/src/index.test.ts
+++ b/packages/dialog/src/index.test.ts
@@ -118,6 +118,23 @@ describe("Dialog", () => {
     controller.destroy();
   });
 
+  it("restores trigger focus on destroy when the original focus target was removed", async () => {
+    const { trigger, controller } = setup();
+    const outside = document.createElement("button");
+    document.body.prepend(outside);
+    outside.focus();
+    try {
+      controller.open();
+      await waitForRaf();
+      outside.remove();
+      controller.destroy();
+      await waitForRaf();
+      expect(document.activeElement).toBe(trigger);
+    } finally {
+      controller.destroy();
+    }
+  });
+
   it("keeps outside focus when destroyed before opening", async () => {
     const { controller } = setup();
     const outside = document.createElement("button");

--- a/packages/dialog/src/index.test.ts
+++ b/packages/dialog/src/index.test.ts
@@ -1040,6 +1040,8 @@ describe("Dialog", () => {
 
     outside.focus();
     controller.open();
+    await waitForRaf();
+    expect(document.activeElement).not.toBe(outside);
     controller.destroy();
     controller.open();
     controller.destroy();

--- a/packages/dialog/src/index.test.ts
+++ b/packages/dialog/src/index.test.ts
@@ -118,6 +118,18 @@ describe("Dialog", () => {
     controller.destroy();
   });
 
+  it("keeps outside focus when destroyed before opening", async () => {
+    const { controller } = setup();
+    const outside = document.createElement("button");
+    document.body.prepend(outside);
+    outside.focus();
+
+    controller.destroy();
+    await waitForRaf();
+
+    expect(document.activeElement).toBe(outside);
+  });
+
   it("opens on trigger click", () => {
     const { trigger, content, controller } = setup();
 

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -124,6 +124,12 @@ export function createDialog(
 
   // Track if this dialog locked scroll (prevent underflow)
   let didLockScroll = false;
+  terminalLifecycle.onDestroy(() => {
+    if (didLockScroll) {
+      unlockScroll();
+      didLockScroll = false;
+    }
+  });
 
   // ARIA setup
   ensureId(content, "dialog-content");
@@ -172,7 +178,7 @@ export function createDialog(
   };
 
   const restoreFocus = () => {
-    requestAnimationFrame(() => {
+    terminalLifecycle.trackRaf(() => {
       if (
         previousActiveElement &&
         document.contains(previousActiveElement) &&

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -16,7 +16,7 @@ import {
   createDismissLayer,
   createPresenceLifecycle,
   createTerminalLifecycle,
-  drainCleanups,
+  registerModalTerminalResources,
   focusElement,
   getAutofocusOrFirstFocusable,
   getTabbables,
@@ -116,7 +116,6 @@ export function createDialog(
 
   let isOpen = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -126,20 +125,14 @@ export function createDialog(
 
   // Track if this dialog locked scroll (prevent underflow)
   let didLockScroll = false;
-  terminalLifecycle.onBeforeDestroy(() => {
+  const restoreFocusOnDestroy = () => {
     terminalLifecycle.trackFinalRaf(() => {
       if (previousActiveElement && document.contains(previousActiveElement)) {
         focusElement(previousActiveElement);
       }
       previousActiveElement = null;
     });
-  });
-  terminalLifecycle.onDestroy(() => {
-    if (didLockScroll) {
-      unlockScroll();
-      didLockScroll = false;
-    }
-  });
+  };
 
   // ARIA setup
   ensureId(content, "dialog-content");
@@ -424,13 +417,22 @@ export function createDialog(
     get isOpen() {
       return isOpen;
     },
-    destroy: () => {
-      if (!terminalLifecycle.destroy()) return;
-      modalStack.destroy();
+    destroy: () => terminalLifecycle.destroy(),
+    // Internal properties for global handler
+    _handleKeydown: handleKeydown,
+    _content: content,
+    _overlay: overlay,
+  };
+
+  registerModalTerminalResources(terminalLifecycle, {
+    cleanups,
+    modalStack,
+    presence: [overlayPresence, contentPresence],
+    portal: portalLifecycle,
+    beforeDestroy: restoreFocusOnDestroy,
+    reset: () => {
       currentExitEpoch += 1;
       pendingExitCount = 0;
-      overlayPresence.cleanup();
-      contentPresence.cleanup();
       isOpen = false;
       setDataState("closed");
       overlay.hidden = true;
@@ -438,20 +440,16 @@ export function createDialog(
       if (trigger) {
         setAria(trigger, "expanded", false);
       }
+    },
+    releaseScrollLock: () => {
       if (didLockScroll) {
         unlockScroll();
         didLockScroll = false;
       }
-      cleanupContentFocusable();
-
-      portalLifecycle?.cleanup();
-      clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
-    // Internal properties for global handler
-    _handleKeydown: handleKeydown,
-    _content: content,
-    _overlay: overlay,
-  };
+    cleanup: cleanupContentFocusable,
+    unbind: () => clearRootBinding(root, ROOT_BINDING_KEY, controller),
+  });
 
   // Inbound event
   cleanups.push(

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -114,7 +114,6 @@ export function createDialog(
   }
 
   let isOpen = false;
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
@@ -220,7 +219,7 @@ export function createDialog(
   let contentExitEpoch = 0;
 
   const finishClosePart = (element: HTMLElement, epoch: number) => {
-    if (isDestroyed || isOpen || epoch !== currentExitEpoch) return;
+    if (terminalLifecycle.isDestroyed || isOpen || epoch !== currentExitEpoch) return;
 
     element.hidden = true;
     pendingExitCount = Math.max(0, pendingExitCount - 1);
@@ -242,7 +241,7 @@ export function createDialog(
   });
 
   const updateState = (open: boolean, force = false) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     if (isOpen === open && !force) return;
 
     if (open) {
@@ -298,7 +297,7 @@ export function createDialog(
     onOpenChange?.(isOpen);
 
     if (open) {
-      requestAnimationFrame(focusFirst);
+      terminalLifecycle.trackRaf(() => focusFirst());
     }
   };
 
@@ -403,15 +402,14 @@ export function createDialog(
   );
 
   const controller: DialogController = {
-    open: () => { if (!isDestroyed) updateState(true); },
-    close: () => { if (!isDestroyed) updateState(false); },
-    toggle: () => { if (!isDestroyed) updateState(!isOpen); },
+    open: () => { if (!terminalLifecycle.isDestroyed) updateState(true); },
+    close: () => { if (!terminalLifecycle.isDestroyed) updateState(false); },
+    toggle: () => { if (!terminalLifecycle.isDestroyed) updateState(!isOpen); },
     get isOpen() {
       return isOpen;
     },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       modalStack.destroy();
       currentExitEpoch += 1;
       pendingExitCount = 0;

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -15,6 +15,7 @@ import {
   createModalStackItem,
   createDismissLayer,
   createPresenceLifecycle,
+  createTerminalLifecycle,
   focusElement,
   getAutofocusOrFirstFocusable,
   getTabbables,
@@ -114,6 +115,7 @@ export function createDialog(
 
   let isOpen = false;
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -240,6 +242,7 @@ export function createDialog(
   });
 
   const updateState = (open: boolean, force = false) => {
+    if (isDestroyed) return;
     if (isOpen === open && !force) return;
 
     if (open) {
@@ -400,13 +403,14 @@ export function createDialog(
   );
 
   const controller: DialogController = {
-    open: () => updateState(true),
-    close: () => updateState(false),
-    toggle: () => updateState(!isOpen),
+    open: () => { if (!isDestroyed) updateState(true); },
+    close: () => { if (!isDestroyed) updateState(false); },
+    toggle: () => { if (!isDestroyed) updateState(!isOpen); },
     get isOpen() {
       return isOpen;
     },
     destroy: () => {
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       modalStack.destroy();
       currentExitEpoch += 1;

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -127,8 +127,12 @@ export function createDialog(
   let didLockScroll = false;
   const restoreFocusOnDestroy = () => {
     terminalLifecycle.trackFinalRaf(() => {
-      if (previousActiveElement && document.contains(previousActiveElement)) {
-        focusElement(previousActiveElement);
+      if (previousActiveElement) {
+        if (document.contains(previousActiveElement)) {
+          focusElement(previousActiveElement);
+        } else if (trigger && document.contains(trigger)) {
+          focusElement(trigger);
+        }
       }
       previousActiveElement = null;
     });

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -421,7 +421,7 @@ export function createDialog(
     get isOpen() {
       return isOpen;
     },
-    destroy: () => terminalLifecycle.destroy(),
+    destroy: () => { terminalLifecycle.destroy(); },
     // Internal properties for global handler
     _handleKeydown: handleKeydown,
     _content: content,

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -16,6 +16,7 @@ import {
   createDismissLayer,
   createPresenceLifecycle,
   createTerminalLifecycle,
+  drainCleanups,
   focusElement,
   getAutofocusOrFirstFocusable,
   getTabbables,
@@ -115,6 +116,7 @@ export function createDialog(
 
   let isOpen = false;
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -443,8 +445,6 @@ export function createDialog(
         didLockScroll = false;
       }
       cleanupContentFocusable();
-      cleanups.forEach((fn) => fn());
-      cleanups.length = 0;
 
       portalLifecycle?.cleanup();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -124,6 +124,16 @@ export function createDialog(
 
   // Track if this dialog locked scroll (prevent underflow)
   let didLockScroll = false;
+  terminalLifecycle.onBeforeDestroy(() => {
+    terminalLifecycle.trackFinalRaf(() => {
+      if (previousActiveElement && document.contains(previousActiveElement)) {
+        focusElement(previousActiveElement);
+      } else if (trigger && document.contains(trigger)) {
+        focusElement(trigger);
+      }
+      previousActiveElement = null;
+    });
+  });
   terminalLifecycle.onDestroy(() => {
     if (didLockScroll) {
       unlockScroll();
@@ -433,9 +443,6 @@ export function createDialog(
         didLockScroll = false;
       }
       cleanupContentFocusable();
-      if (previousActiveElement !== null) {
-        restoreFocus();
-      }
       cleanups.forEach((fn) => fn());
       cleanups.length = 0;
 

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -116,7 +116,7 @@ export function createDialog(
 
   let isOpen = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   let previousActiveElement: HTMLElement | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -130,8 +130,6 @@ export function createDialog(
     terminalLifecycle.trackFinalRaf(() => {
       if (previousActiveElement && document.contains(previousActiveElement)) {
         focusElement(previousActiveElement);
-      } else if (trigger && document.contains(trigger)) {
-        focusElement(trigger);
       }
       previousActiveElement = null;
     });

--- a/packages/dropdown-menu/README.md
+++ b/packages/dropdown-menu/README.md
@@ -352,15 +352,14 @@ createDropdownMenu(root, {
 
 When `avoidCollisions` is enabled, the menu may flip sides or shift within the viewport. The positioned element also receives `--transform-origin` for animation origins.
 
-## License
-
-MIT
-
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the
 old controller become no-ops. Create a new controller on the same root to rebind it.
 
 Focus restoration already queued by a close survives destruction.
+
+## License
+
+MIT

--- a/packages/dropdown-menu/README.md
+++ b/packages/dropdown-menu/README.md
@@ -355,3 +355,12 @@ When `avoidCollisions` is enabled, the menu may flip sides or shift within the v
 ## License
 
 MIT
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.
+
+Focus restoration already queued by a close survives destruction.

--- a/packages/dropdown-menu/src/index.test.ts
+++ b/packages/dropdown-menu/src/index.test.ts
@@ -42,6 +42,32 @@ describe("DropdownMenu", () => {
     return { root, trigger, content, items, controller };
   };
 
+  it("preserves queued item-selection focus restoration when destroyed before the next frame", async () => {
+    const { trigger, content, controller } = setup();
+    trigger.focus();
+    controller.open();
+    await waitForRaf();
+    await waitForRaf();
+    content.focus();
+    content.querySelector<HTMLButtonElement>('[data-slot="dropdown-menu-item"]')!.click();
+    await waitForRaf();
+    controller.destroy();
+    controller.destroy();
+    await waitForRaf();
+    await waitForRaf();
+    expect(document.activeElement === trigger).toBe(true);
+  });
+
+  it("does not move outside focus when destroyed without a pending restoration", async () => {
+    const { controller } = setup();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.focus();
+    controller.destroy();
+    await waitForRaf();
+    expect(document.activeElement === outside).toBe(true);
+  });
+
   const waitForRaf = () =>
     new Promise<void>((resolve) => {
       requestAnimationFrame(() => resolve());

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -831,10 +831,6 @@ export function createDropdownMenu(
       setAria(trigger, "expanded", false);
       setDataState("closed");
       content.hidden = true;
-      if (didLockScroll) {
-        unlockScroll();
-        didLockScroll = false;
-      }
     },
   };
 

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -409,6 +409,7 @@ export function createDropdownMenu(
     syncItems();
   };
   const updateOpenState = (open: boolean, { source, reason }: OpenTransitionOptions) => {
+    if (isDestroyed) return;
     if (isOpen === open) return;
     pendingDismissMeta = null;
     const previousOpen = isOpen;
@@ -784,22 +785,23 @@ export function createDropdownMenu(
     }),
   );
   const controller: DropdownMenuController = {
-    open: () =>
+    open: () => !isDestroyed &&
       updateOpenState(true, {
         source: "programmatic",
         reason: "programmatic",
       }),
-    close: () =>
+    close: () => !isDestroyed &&
       updateOpenState(false, {
         source: "programmatic",
         reason: "programmatic",
       }),
-    toggle: () =>
+    toggle: () => !isDestroyed &&
       updateOpenState(!isOpen, {
         source: "programmatic",
         reason: "programmatic",
       }),
     set: (detail) => {
+      if (isDestroyed) return;
       applySet(detail);
     },
     get isOpen() {

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -139,8 +139,13 @@ export function createDropdownMenu(
   const typeahead = createTypeahead();
   let keyboardMode = false;
   let didLockScroll = false;
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroy(() => {
+    if (didLockScroll) {
+      unlockScroll();
+      didLockScroll = false;
+    }
+  });
   let pendingDismissMeta: Pick<DropdownMenuOpenChangeDetail, "source" | "reason"> | null = null;
   const cleanups: Array<() => void> = [];
   const portal = createPortalLifecycle({
@@ -264,7 +269,7 @@ export function createDropdownMenu(
     onUpdate: updatePosition,
   });
   const restoreFocus = () => {
-    requestAnimationFrame(() => {
+    terminalLifecycle.trackRaf(() => {
       if (previousActiveElement && document.contains(previousActiveElement)) {
         focusElement(previousActiveElement);
       } else if (document.contains(trigger)) {
@@ -276,7 +281,7 @@ export function createDropdownMenu(
   const presence = createPresenceLifecycle({
     element: content,
     onExitComplete: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       portal.restore();
       content.hidden = true;
       restoreFocus();
@@ -411,7 +416,7 @@ export function createDropdownMenu(
     syncItems();
   };
   const updateOpenState = (open: boolean, { source, reason }: OpenTransitionOptions) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     if (isOpen === open) return;
     pendingDismissMeta = null;
     const previousOpen = isOpen;
@@ -787,23 +792,23 @@ export function createDropdownMenu(
     }),
   );
   const controller: DropdownMenuController = {
-    open: () => !isDestroyed &&
+    open: () => !terminalLifecycle.isDestroyed &&
       updateOpenState(true, {
         source: "programmatic",
         reason: "programmatic",
       }),
-    close: () => !isDestroyed &&
+    close: () => !terminalLifecycle.isDestroyed &&
       updateOpenState(false, {
         source: "programmatic",
         reason: "programmatic",
       }),
-    toggle: () => !isDestroyed &&
+    toggle: () => !terminalLifecycle.isDestroyed &&
       updateOpenState(!isOpen, {
         source: "programmatic",
         reason: "programmatic",
       }),
     set: (detail) => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       applySet(detail);
     },
     get isOpen() {
@@ -820,7 +825,6 @@ export function createDropdownMenu(
     },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       typeahead.destroy();
       isOpen = false;
       setAria(trigger, "expanded", false);

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -21,6 +21,7 @@ import {
   createPositionSync,
   createPortalLifecycle,
   createPresenceLifecycle,
+  createTerminalLifecycle,
   createDismissLayer,
   containsWithPortals,
   createTypeahead,
@@ -139,6 +140,7 @@ export function createDropdownMenu(
   let keyboardMode = false;
   let didLockScroll = false;
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
   let pendingDismissMeta: Pick<DropdownMenuOpenChangeDetail, "source" | "reason"> | null = null;
   const cleanups: Array<() => void> = [];
   const portal = createPortalLifecycle({
@@ -817,7 +819,7 @@ export function createDropdownMenu(
       return itemCollection.valueFor(itemCollection.recordFor(highlightedItem));
     },
     destroy: () => {
-      if (isDestroyed) return;
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       typeahead.destroy();
       isOpen = false;

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -22,7 +22,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
-  drainCleanups,
+  registerFloatingTerminalResources,
   createDismissLayer,
   containsWithPortals,
   createTypeahead,
@@ -141,7 +141,6 @@ export function createDropdownMenu(
   let keyboardMode = false;
   let didLockScroll = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   terminalLifecycle.onDestroy(() => {
     if (didLockScroll) {
       unlockScroll();
@@ -831,17 +830,22 @@ export function createDropdownMenu(
       isOpen = false;
       setAria(trigger, "expanded", false);
       setDataState("closed");
-      positionSync.stop();
-      presence.cleanup();
-      portal.cleanup();
       content.hidden = true;
       if (didLockScroll) {
         unlockScroll();
         didLockScroll = false;
       }
-      clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };
+
+  registerFloatingTerminalResources(terminalLifecycle, {
+    cleanups,
+    positionSync,
+    presence,
+    portal,
+    unbind: () => clearRootBinding(root, ROOT_BINDING_KEY, controller),
+  });
+
   setRootBinding(root, ROOT_BINDING_KEY, controller);
   if (defaultOpen) {
     updateOpenState(true, {

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -815,11 +815,16 @@ export function createDropdownMenu(
       return itemCollection.valueFor(itemCollection.recordFor(highlightedItem));
     },
     destroy: () => {
+      if (isDestroyed) return;
       isDestroyed = true;
       typeahead.destroy();
+      isOpen = false;
+      setAria(trigger, "expanded", false);
+      setDataState("closed");
       positionSync.stop();
       presence.cleanup();
       portal.cleanup();
+      content.hidden = true;
       if (didLockScroll) {
         unlockScroll();
         didLockScroll = false;

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -269,16 +269,23 @@ export function createDropdownMenu(
     ancestorScroll: lockScrollOption,
     onUpdate: updatePosition,
   });
-  const restoreFocus = () => {
-    terminalLifecycle.trackRaf(() => {
-      if (previousActiveElement && document.contains(previousActiveElement)) {
-        focusElement(previousActiveElement);
-      } else if (document.contains(trigger)) {
-        focusElement(trigger);
-      }
-      previousActiveElement = null;
-    });
+  let pendingFocusRestore = false;
+  const restoreFocusNow = () => {
+    pendingFocusRestore = false;
+    if (previousActiveElement && document.contains(previousActiveElement)) {
+      focusElement(previousActiveElement);
+    } else if (document.contains(trigger)) {
+      focusElement(trigger);
+    }
+    previousActiveElement = null;
   };
+  const restoreFocus = () => {
+    pendingFocusRestore = true;
+    terminalLifecycle.trackRaf(restoreFocusNow);
+  };
+  terminalLifecycle.onBeforeDestroy(() => {
+    if (pendingFocusRestore) terminalLifecycle.trackFinalRaf(restoreFocusNow);
+  });
   const presence = createPresenceLifecycle({
     element: content,
     onExitComplete: () => {

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -22,6 +22,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
+  drainCleanups,
   createDismissLayer,
   containsWithPortals,
   createTypeahead,
@@ -140,6 +141,7 @@ export function createDropdownMenu(
   let keyboardMode = false;
   let didLockScroll = false;
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
   terminalLifecycle.onDestroy(() => {
     if (didLockScroll) {
       unlockScroll();
@@ -837,8 +839,6 @@ export function createDropdownMenu(
         unlockScroll();
         didLockScroll = false;
       }
-      cleanups.forEach((cleanup) => cleanup());
-      cleanups.length = 0;
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };

--- a/packages/dropdown-menu/src/index.ts
+++ b/packages/dropdown-menu/src/index.ts
@@ -141,7 +141,7 @@ export function createDropdownMenu(
   let keyboardMode = false;
   let didLockScroll = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   terminalLifecycle.onDestroy(() => {
     if (didLockScroll) {
       unlockScroll();

--- a/packages/hover-card/README.md
+++ b/packages/hover-card/README.md
@@ -249,3 +249,10 @@ The component automatically handles:
 ## License
 
 MIT
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.

--- a/packages/hover-card/README.md
+++ b/packages/hover-card/README.md
@@ -246,13 +246,12 @@ The component automatically handles:
 - `aria-expanded` state on trigger
 - Unique content IDs via `ensureId`
 
-## License
-
-MIT
-
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the
 old controller become no-ops. Create a new controller on the same root to rebind it.
+
+## License
+
+MIT

--- a/packages/hover-card/src/index.test.ts
+++ b/packages/hover-card/src/index.test.ts
@@ -65,6 +65,16 @@ describe('HoverCard', () => {
     await waitForRaf()
   }
 
+  it('does not open from a pending hover timer after destroy', async () => {
+    const { trigger, content, controller } = setup({ delay: 10 })
+    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse' }))
+    controller.destroy()
+    await wait(20)
+
+    expect(controller.isOpen).toBe(false)
+    expect(content.hidden).toBe(true)
+  })
+
   const getPositioner = (content: HTMLElement): HTMLElement => {
     const parent = content.parentElement
     if (parent && parent.getAttribute('data-slot') === 'hover-card-positioner') {

--- a/packages/hover-card/src/index.ts
+++ b/packages/hover-card/src/index.ts
@@ -230,13 +230,13 @@ export function createHoverCard(
 
   const clearOpenTimeout = () => {
     if (!openTimeout) return;
-    clearTimeout(openTimeout);
+    terminalLifecycle.cancelTimeout(openTimeout);
     openTimeout = null;
   };
 
   const clearCloseTimeout = () => {
     if (!closeTimeout) return;
-    clearTimeout(closeTimeout);
+    terminalLifecycle.cancelTimeout(closeTimeout);
     closeTimeout = null;
   };
 

--- a/packages/hover-card/src/index.ts
+++ b/packages/hover-card/src/index.ts
@@ -371,6 +371,7 @@ export function createHoverCard(
   });
 
   const applyState = (open: boolean, reason: HoverCardReason, instant = false) => {
+    if (isDestroyed) return;
     if (isOpen === open) return;
 
     if (!open && isOpen && skipDelayDuration > 0) {
@@ -449,6 +450,7 @@ export function createHoverCard(
 
     openTimeout = setTimeout(() => {
       openTimeout = null;
+      if (isDestroyed) return;
       requestState(true, reason);
     }, delay);
   };
@@ -464,6 +466,7 @@ export function createHoverCard(
 
     closeTimeout = setTimeout(() => {
       closeTimeout = null;
+      if (isDestroyed) return;
       requestState(false, reason);
     }, closeDelay);
   };
@@ -621,14 +624,17 @@ export function createHoverCard(
 
   const controller: HoverCardController = {
     open: () => {
+      if (isDestroyed) return;
       if (isTriggerDisabled()) return;
       clearTimers();
       requestState(true, "api");
     },
     close: () => {
+      if (isDestroyed) return;
       requestClosedState("api");
     },
     toggle: () => {
+      if (isDestroyed) return;
       if (!isOpen && isTriggerDisabled()) return;
       if (isOpen) {
         requestClosedState("api");
@@ -638,6 +644,7 @@ export function createHoverCard(
       }
     },
     setOpen: (open) => {
+      if (isDestroyed) return;
       if (open) {
         clearTimers();
         forceState(true, "api");

--- a/packages/hover-card/src/index.ts
+++ b/packages/hover-card/src/index.ts
@@ -200,7 +200,7 @@ export function createHoverCard(
   let isOpen = options.open ?? defaultOpen;
   let isInstantTransition = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   let pointerOnTrigger = false;
   let pointerOnContent = false;
   let focusWithin = false;

--- a/packages/hover-card/src/index.ts
+++ b/packages/hover-card/src/index.ts
@@ -649,11 +649,16 @@ export function createHoverCard(
       return isOpen;
     },
     destroy: () => {
+      if (isDestroyed) return;
       isDestroyed = true;
       resetInteractionState();
+      isOpen = false;
+      setAria(trigger, "expanded", false);
+      setDataState("closed");
       positionSync.stop();
       presence.cleanup();
       portal.cleanup();
+      content.hidden = true;
       cleanups.forEach((fn) => fn());
       cleanups.length = 0;
       clearRootBinding(root, ROOT_BINDING_KEY, controller);

--- a/packages/hover-card/src/index.ts
+++ b/packages/hover-card/src/index.ts
@@ -198,7 +198,6 @@ export function createHoverCard(
 
   let isOpen = options.open ?? defaultOpen;
   let isInstantTransition = false;
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
   let pointerOnTrigger = false;
   let pointerOnContent = false;
@@ -359,7 +358,7 @@ export function createHoverCard(
   const presence = createPresenceLifecycle({
     element: content,
     onExitComplete: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       portal.restore();
       content.hidden = true;
     },
@@ -373,7 +372,7 @@ export function createHoverCard(
   });
 
   const applyState = (open: boolean, reason: HoverCardReason, instant = false) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     if (isOpen === open) return;
 
     if (!open && isOpen && skipDelayDuration > 0) {
@@ -450,9 +449,9 @@ export function createHoverCard(
       return;
     }
 
-    openTimeout = setTimeout(() => {
+    openTimeout = terminalLifecycle.trackTimeout(() => {
       openTimeout = null;
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       requestState(true, reason);
     }, delay);
   };
@@ -466,9 +465,9 @@ export function createHoverCard(
       return;
     }
 
-    closeTimeout = setTimeout(() => {
+    closeTimeout = terminalLifecycle.trackTimeout(() => {
       closeTimeout = null;
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       requestState(false, reason);
     }, closeDelay);
   };
@@ -626,17 +625,17 @@ export function createHoverCard(
 
   const controller: HoverCardController = {
     open: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       if (isTriggerDisabled()) return;
       clearTimers();
       requestState(true, "api");
     },
     close: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       requestClosedState("api");
     },
     toggle: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       if (!isOpen && isTriggerDisabled()) return;
       if (isOpen) {
         requestClosedState("api");
@@ -646,7 +645,7 @@ export function createHoverCard(
       }
     },
     setOpen: (open) => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       if (open) {
         clearTimers();
         forceState(true, "api");
@@ -659,7 +658,6 @@ export function createHoverCard(
     },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       resetInteractionState();
       isOpen = false;
       setAria(trigger, "expanded", false);

--- a/packages/hover-card/src/index.ts
+++ b/packages/hover-card/src/index.ts
@@ -16,6 +16,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
+  drainCleanups,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -199,6 +200,7 @@ export function createHoverCard(
   let isOpen = options.open ?? defaultOpen;
   let isInstantTransition = false;
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
   let pointerOnTrigger = false;
   let pointerOnContent = false;
   let focusWithin = false;
@@ -666,8 +668,6 @@ export function createHoverCard(
       presence.cleanup();
       portal.cleanup();
       content.hidden = true;
-      cleanups.forEach((fn) => fn());
-      cleanups.length = 0;
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };

--- a/packages/hover-card/src/index.ts
+++ b/packages/hover-card/src/index.ts
@@ -16,7 +16,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
-  drainCleanups,
+  registerFloatingTerminalResources,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -200,7 +200,6 @@ export function createHoverCard(
   let isOpen = options.open ?? defaultOpen;
   let isInstantTransition = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   let pointerOnTrigger = false;
   let pointerOnContent = false;
   let focusWithin = false;
@@ -664,13 +663,17 @@ export function createHoverCard(
       isOpen = false;
       setAria(trigger, "expanded", false);
       setDataState("closed");
-      positionSync.stop();
-      presence.cleanup();
-      portal.cleanup();
       content.hidden = true;
-      clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };
+
+  registerFloatingTerminalResources(terminalLifecycle, {
+    cleanups,
+    positionSync,
+    presence,
+    portal,
+    unbind: () => clearRootBinding(root, ROOT_BINDING_KEY, controller),
+  });
 
   setRootBinding(root, ROOT_BINDING_KEY, controller);
   return controller;

--- a/packages/hover-card/src/index.ts
+++ b/packages/hover-card/src/index.ts
@@ -15,6 +15,7 @@ import {
   createPositionSync,
   createPortalLifecycle,
   createPresenceLifecycle,
+  createTerminalLifecycle,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -198,6 +199,7 @@ export function createHoverCard(
   let isOpen = options.open ?? defaultOpen;
   let isInstantTransition = false;
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
   let pointerOnTrigger = false;
   let pointerOnContent = false;
   let focusWithin = false;
@@ -656,7 +658,7 @@ export function createHoverCard(
       return isOpen;
     },
     destroy: () => {
-      if (isDestroyed) return;
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       resetInteractionState();
       isOpen = false;

--- a/packages/navigation-menu/README.md
+++ b/packages/navigation-menu/README.md
@@ -424,13 +424,12 @@ element.dispatchEvent(
 );
 ```
 
-## License
-
-MIT
-
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the
 old controller become no-ops. Create a new controller on the same root to rebind it.
+
+## License
+
+MIT

--- a/packages/navigation-menu/README.md
+++ b/packages/navigation-menu/README.md
@@ -427,3 +427,10 @@ element.dispatchEvent(
 ## License
 
 MIT
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -476,6 +476,7 @@ export function createNavigationMenu(
   });
 
   const updateState = (value: string | null, immediate = false) => {
+    if (isDestroyed) return;
     safety.clear();
     // Skip if value hasn't changed
     if (value === currentValue) {
@@ -1170,8 +1171,8 @@ export function createNavigationMenu(
     get value() {
       return currentValue;
     },
-    open: (value: string) => updateState(value, true),
-    close: () => closeMenuAndUnlock(),
+    open: (value: string) => { if (!isDestroyed) updateState(value, true); },
+    close: () => { if (!isDestroyed) closeMenuAndUnlock(); },
     destroy: () => {
       if (isDestroyed) return;
       isDestroyed = true;

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -10,6 +10,7 @@ import {
   setRootBinding,
   clearRootBinding,
   getTabbables,
+  createTerminalLifecycle,
 } from "@data-slot/core";
 import { createPresenceLifecycle, setAria } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -142,6 +143,7 @@ export function createNavigationMenu(
   let pointerActivationTrigger: HTMLElement | null = null;
   let isRootHovered: boolean = false; // Track if pointer is over root
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
 
   const cleanups: Array<() => void> = [];
   const presences = new Map<
@@ -1174,7 +1176,7 @@ export function createNavigationMenu(
     open: (value: string) => { if (!isDestroyed) updateState(value, true); },
     close: () => { if (!isDestroyed) closeMenuAndUnlock(); },
     destroy: () => {
-      if (isDestroyed) return;
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       resetPendingInteraction();
       resetPointerIntent();

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -1173,9 +1173,25 @@ export function createNavigationMenu(
     open: (value: string) => updateState(value, true),
     close: () => closeMenuAndUnlock(),
     destroy: () => {
+      if (isDestroyed) return;
       isDestroyed = true;
       resetPendingInteraction();
       resetPointerIntent();
+      layout.stop();
+      itemMap.forEach(({ trigger, content, item }) => {
+        setAria(trigger, "expanded", false);
+        trigger.setAttribute("data-state", "closed");
+        item.setAttribute("data-state", "closed");
+        setContentSurfaceState(content, false);
+        content.setAttribute("aria-hidden", "true");
+        setInert(content, true);
+        content.hidden = true;
+        content.style.pointerEvents = "none";
+        presences.get(content)?.cleanup();
+        layout.restore(content);
+      });
+      currentValue = null;
+      popupStackController.destroy();
       for (const cleanup of cleanups.splice(0)) cleanup();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -627,8 +627,8 @@ export function createNavigationMenu(
         updateIndicator(newData.trigger); // Indicator follows active trigger
       } else {
         clearIndicatorSyncRaf();
-      updateIndicator(null);
-      layout.stop();
+        updateIndicator(null);
+        layout.stop();
         safety.hideBridge();
         safety.clear();
         popupStackController.close(popupSizeBaseline);
@@ -1200,7 +1200,6 @@ export function createNavigationMenu(
       resetPointerIntent();
       clearIndicatorSyncRaf();
       updateIndicator(null);
-      layout.stop();
       itemMap.forEach(({ trigger, content, item }) => {
         setAria(trigger, "expanded", false);
         trigger.setAttribute("data-state", "closed");
@@ -1210,11 +1209,8 @@ export function createNavigationMenu(
         setInert(content, true);
         content.hidden = true;
         content.style.pointerEvents = "none";
-        presences.get(content)?.cleanup();
-        layout.restore(content);
       });
       currentValue = null;
-      popupStackController.destroy();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -145,6 +145,13 @@ export function createNavigationMenu(
   let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
 
+  let indicatorSyncRaf: number | null = null;
+  const clearIndicatorSyncRaf = () => {
+    if (indicatorSyncRaf !== null) {
+      cancelAnimationFrame(indicatorSyncRaf);
+      indicatorSyncRaf = null;
+    }
+  };
   const cleanups: Array<() => void> = [];
   const presences = new Map<
     HTMLElement,
@@ -448,6 +455,7 @@ export function createNavigationMenu(
 
   // Update hover indicator position
   const updateIndicator = (trigger: HTMLElement | null) => {
+    if (!trigger) clearIndicatorSyncRaf();
     hoveredTrigger = trigger;
     navigationIndicator.show(trigger);
   };
@@ -617,7 +625,9 @@ export function createNavigationMenu(
         layout.observe(newData);
         updateIndicator(newData.trigger); // Indicator follows active trigger
       } else {
-        layout.stop();
+        clearIndicatorSyncRaf();
+      updateIndicator(null);
+      layout.stop();
         safety.hideBridge();
         safety.clear();
         popupStackController.close(popupSizeBaseline);
@@ -1140,12 +1150,20 @@ export function createNavigationMenu(
   cleanups.push(
     on(window, "resize", () => {
       if (currentValue || hoveredTrigger) {
-        requestAnimationFrame(() => syncIndicator(hoveredTrigger));
+        clearIndicatorSyncRaf();
+        indicatorSyncRaf = requestAnimationFrame(() => {
+          indicatorSyncRaf = null;
+          if (!isDestroyed) syncIndicator(hoveredTrigger);
+        });
       }
     }),
     on(list, "scroll", () => {
       if (currentValue || hoveredTrigger) {
-        requestAnimationFrame(() => syncIndicator(hoveredTrigger));
+        clearIndicatorSyncRaf();
+        indicatorSyncRaf = requestAnimationFrame(() => {
+          indicatorSyncRaf = null;
+          if (!isDestroyed) syncIndicator(hoveredTrigger);
+        });
       }
     }),
   );
@@ -1180,6 +1198,8 @@ export function createNavigationMenu(
       isDestroyed = true;
       resetPendingInteraction();
       resetPointerIntent();
+      clearIndicatorSyncRaf();
+      updateIndicator(null);
       layout.stop();
       itemMap.forEach(({ trigger, content, item }) => {
         setAria(trigger, "expanded", false);

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -11,6 +11,7 @@ import {
   clearRootBinding,
   getTabbables,
   createTerminalLifecycle,
+  drainCleanups,
 } from "@data-slot/core";
 import { createPresenceLifecycle, setAria } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -143,6 +144,7 @@ export function createNavigationMenu(
   let pointerActivationTrigger: HTMLElement | null = null;
   let isRootHovered: boolean = false; // Track if pointer is over root
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
 
   let indicatorSyncRaf: number | null = null;
   const clearIndicatorSyncRaf = () => {
@@ -1213,7 +1215,6 @@ export function createNavigationMenu(
       });
       currentValue = null;
       popupStackController.destroy();
-      for (const cleanup of cleanups.splice(0)) cleanup();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -144,7 +144,7 @@ export function createNavigationMenu(
   let pointerActivationTrigger: HTMLElement | null = null;
   let isRootHovered: boolean = false; // Track if pointer is over root
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
 
   let indicatorSyncRaf: number | null = null;
   const clearIndicatorSyncRaf = () => {

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -149,7 +149,7 @@ export function createNavigationMenu(
   let indicatorSyncRaf: number | null = null;
   const clearIndicatorSyncRaf = () => {
     if (indicatorSyncRaf !== null) {
-      cancelAnimationFrame(indicatorSyncRaf);
+      terminalLifecycle.cancelRaf(indicatorSyncRaf);
       indicatorSyncRaf = null;
     }
   };
@@ -400,11 +400,11 @@ export function createNavigationMenu(
 
   const clearTimers = () => {
     if (openTimeout) {
-      clearTimeout(openTimeout);
+      terminalLifecycle.cancelTimeout(openTimeout);
       openTimeout = null;
     }
     if (closeTimeout) {
-      clearTimeout(closeTimeout);
+      terminalLifecycle.cancelTimeout(closeTimeout);
       closeTimeout = null;
     }
   };

--- a/packages/navigation-menu/src/navigation-menu-controller.ts
+++ b/packages/navigation-menu/src/navigation-menu-controller.ts
@@ -142,7 +142,6 @@ export function createNavigationMenu(
   let suppressFocusOpenForTrigger: HTMLElement | null = null;
   let pointerActivationTrigger: HTMLElement | null = null;
   let isRootHovered: boolean = false; // Track if pointer is over root
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
 
   let indicatorSyncRaf: number | null = null;
@@ -187,7 +186,7 @@ export function createNavigationMenu(
   const popupStackController = createNavigationMenuPopupStack({
     root,
     viewport,
-    isDestroyed: () => isDestroyed,
+    isDestroyed: () => terminalLifecycle.isDestroyed,
     beforeRestore: () => resetLayout(),
   });
   const getCurrentPopup = () => popupStackController.popup;
@@ -206,7 +205,7 @@ export function createNavigationMenu(
       createPresenceLifecycle({
         element: content,
         onExitComplete: () => {
-          if (isDestroyed) return;
+          if (terminalLifecycle.isDestroyed) return;
           setContentSurfaceState(content, false);
           setContentActivationDirection(content, null);
           content.removeAttribute("data-motion");
@@ -386,7 +385,7 @@ export function createNavigationMenu(
   };
 
   const focusContentForValue = (value: string): void => {
-    requestAnimationFrame(() => {
+    terminalLifecycle.trackRaf(() => {
       if (currentValue !== value) return;
       const data = itemMap.get(value);
       if (!data) return;
@@ -486,7 +485,7 @@ export function createNavigationMenu(
   });
 
   const updateState = (value: string | null, immediate = false) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     safety.clear();
     // Skip if value hasn't changed
     if (value === currentValue) {
@@ -683,13 +682,13 @@ export function createNavigationMenu(
       doUpdate();
     } else if (value !== null && currentValue === null) {
       // Opening - use delay
-      openTimeout = setTimeout(doUpdate, delayOpen);
+      openTimeout = terminalLifecycle.trackTimeout(doUpdate, delayOpen);
     } else if (value !== null && currentValue !== null) {
       // Switching between items - instant
       doUpdate();
     } else {
       // Closing - use delay
-      closeTimeout = setTimeout(doUpdate, delayClose);
+      closeTimeout = terminalLifecycle.trackTimeout(doUpdate, delayClose);
     }
   };
 
@@ -1151,18 +1150,18 @@ export function createNavigationMenu(
     on(window, "resize", () => {
       if (currentValue || hoveredTrigger) {
         clearIndicatorSyncRaf();
-        indicatorSyncRaf = requestAnimationFrame(() => {
+        indicatorSyncRaf = terminalLifecycle.trackRaf(() => {
           indicatorSyncRaf = null;
-          if (!isDestroyed) syncIndicator(hoveredTrigger);
+          if (!terminalLifecycle.isDestroyed) syncIndicator(hoveredTrigger);
         });
       }
     }),
     on(list, "scroll", () => {
       if (currentValue || hoveredTrigger) {
         clearIndicatorSyncRaf();
-        indicatorSyncRaf = requestAnimationFrame(() => {
+        indicatorSyncRaf = terminalLifecycle.trackRaf(() => {
           indicatorSyncRaf = null;
-          if (!isDestroyed) syncIndicator(hoveredTrigger);
+          if (!terminalLifecycle.isDestroyed) syncIndicator(hoveredTrigger);
         });
       }
     }),
@@ -1191,11 +1190,10 @@ export function createNavigationMenu(
     get value() {
       return currentValue;
     },
-    open: (value: string) => { if (!isDestroyed) updateState(value, true); },
-    close: () => { if (!isDestroyed) closeMenuAndUnlock(); },
+    open: (value: string) => { if (!terminalLifecycle.isDestroyed) updateState(value, true); },
+    close: () => { if (!terminalLifecycle.isDestroyed) closeMenuAndUnlock(); },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       resetPendingInteraction();
       resetPointerIntent();
       clearIndicatorSyncRaf();

--- a/packages/navigation-menu/src/navigation-menu-indicator.ts
+++ b/packages/navigation-menu/src/navigation-menu-indicator.ts
@@ -4,7 +4,7 @@ export function createNavigationMenuIndicator(indicator: HTMLElement | null, lis
   const terminalLifecycle = createTerminalLifecycle();
   let hovered: HTMLElement | null = null;
   let instantRaf: number | null = null;
-  const clearFrame = () => { if (instantRaf !== null) { cancelAnimationFrame(instantRaf); instantRaf = null; } };
+  const clearFrame = () => { if (instantRaf !== null) { terminalLifecycle.cancelRaf(instantRaf); instantRaf = null; } };
   const show = (target: HTMLElement | null) => {
     if (!indicator) return;
     hovered = target;

--- a/packages/navigation-menu/src/navigation-menu-indicator.ts
+++ b/packages/navigation-menu/src/navigation-menu-indicator.ts
@@ -1,4 +1,7 @@
+import { createTerminalLifecycle } from "@data-slot/core";
+
 export function createNavigationMenuIndicator(indicator: HTMLElement | null, list: HTMLElement, viewport: HTMLElement | null, activeTrigger: () => HTMLElement | null) {
+  const terminalLifecycle = createTerminalLifecycle();
   let hovered: HTMLElement | null = null;
   let instantRaf: number | null = null;
   const clearFrame = () => { if (instantRaf !== null) { cancelAnimationFrame(instantRaf); instantRaf = null; } };
@@ -8,7 +11,7 @@ export function createNavigationMenuIndicator(indicator: HTMLElement | null, lis
     if (!target) { clearFrame(); indicator.removeAttribute("data-instant"); indicator.setAttribute("data-state", "hidden"); return; }
     if (indicator.getAttribute("data-state") !== "visible") {
       clearFrame(); indicator.setAttribute("data-instant", "");
-      instantRaf = requestAnimationFrame(() => { instantRaf = requestAnimationFrame(() => { indicator?.removeAttribute("data-instant"); instantRaf = null; }); });
+      instantRaf = terminalLifecycle.trackRaf(() => { instantRaf = terminalLifecycle.trackRaf(() => { indicator?.removeAttribute("data-instant"); instantRaf = null; }); });
     }
     const listRect = list.getBoundingClientRect(); const rect = target.getBoundingClientRect();
     indicator.style.setProperty("--indicator-left", `${rect.left - listRect.left}px`);
@@ -19,5 +22,5 @@ export function createNavigationMenuIndicator(indicator: HTMLElement | null, lis
     indicator.setAttribute("data-state", "visible");
   };
   const sync = (preferred: HTMLElement | null = null) => show(activeTrigger() ?? preferred);
-  return { show, sync, get hovered() { return hovered; }, destroy() { clearFrame(); hovered = null; } };
+  return { show, sync, get hovered() { return hovered; }, destroy() { terminalLifecycle.destroy(); clearFrame(); hovered = null; } };
 }

--- a/packages/navigation-menu/src/navigation-menu-layout.ts
+++ b/packages/navigation-menu/src/navigation-menu-layout.ts
@@ -1,3 +1,4 @@
+import { createTerminalLifecycle } from "@data-slot/core";
 import {
   computeFloatingPosition,
   createPositionSync,
@@ -149,7 +150,7 @@ export function createNavigationMenuLayout(
   let measureRaf: number | null = null;
   let resizeObserver: ResizeObserver | null = null;
   let mutationObserver: MutationObserver | null = null;
-  let destroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
 
   const resolvePlacement = (panel: Panel): PlacementConfig => ({
     side:
@@ -191,7 +192,7 @@ export function createNavigationMenuLayout(
   };
   const scheduleInstantClear = () => {
     clearInstantRaf();
-    instantRaf = requestAnimationFrame(() => {
+    instantRaf = terminalLifecycle.trackRaf(() => {
       instantRaf = null;
       if (initialInstant && initialInstantFrames > 0) {
         initialInstantFrames -= 1;
@@ -410,13 +411,13 @@ export function createNavigationMenuLayout(
     const run = () => apply(panel, config.mode ?? "measure-target");
     if (config.defer === false) run();
     else
-      requestAnimationFrame(() => {
-        if (!destroyed) run();
+      terminalLifecycle.trackRaf(() => {
+        if (!terminalLifecycle.isDestroyed) run();
       });
   };
   const schedule = () => {
     clearMeasure();
-    measureRaf = requestAnimationFrame(() => {
+    measureRaf = terminalLifecycle.trackRaf(() => {
       measureRaf = null;
       const selection = readSelection();
       if (!selection.panel || !popup.ensure() || popup.closing) return;
@@ -512,8 +513,7 @@ export function createNavigationMenuLayout(
     reset();
   };
   const destroy = () => {
-    if (destroyed) return;
-    destroyed = true;
+    if (!terminalLifecycle.destroy()) return;
     dispose();
     for (const content of contentPlacement.keys()) {
       restore(content);

--- a/packages/navigation-menu/src/navigation-menu-layout.ts
+++ b/packages/navigation-menu/src/navigation-menu-layout.ts
@@ -175,11 +175,11 @@ export function createNavigationMenuLayout(
       rootAlignOffset,
   });
   const clearMeasure = () => {
-    if (measureRaf !== null) cancelAnimationFrame(measureRaf);
+    if (measureRaf !== null) terminalLifecycle.cancelRaf(measureRaf);
     measureRaf = null;
   };
   const clearInstantRaf = () => {
-    if (instantRaf !== null) cancelAnimationFrame(instantRaf);
+    if (instantRaf !== null) terminalLifecycle.cancelRaf(instantRaf);
     instantRaf = null;
   };
   const syncInstant = () => {

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -318,3 +318,12 @@ Use the replacements listed above.
 ## License
 
 MIT
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.
+
+Focus restoration already queued by a close survives destruction.

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -315,15 +315,14 @@ element.dispatchEvent(
 
 Use the replacements listed above.
 
-## License
-
-MIT
-
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the
 old controller become no-ops. Create a new controller on the same root to rebind it.
 
 Focus restoration already queued by a close survives destruction.
+
+## License
+
+MIT

--- a/packages/popover/src/index.test.ts
+++ b/packages/popover/src/index.test.ts
@@ -26,6 +26,32 @@ describe('Popover', () => {
     return { root, trigger, content, closeBtn, controller }
   }
 
+  it("preserves queued close focus restoration when destroyed before the next frame", async () => {
+    const { trigger, content, controller } = setup();
+    trigger.focus();
+    controller.open();
+    await waitForRaf();
+    await waitForRaf();
+    content.focus();
+    controller.close();
+    await waitForRaf();
+    controller.destroy();
+    controller.destroy();
+    await waitForRaf();
+    await waitForRaf();
+    expect(document.activeElement === trigger).toBe(true);
+  });
+
+  it("does not move outside focus when destroyed without a pending restoration", async () => {
+    const { controller } = setup();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.focus();
+    controller.destroy();
+    await waitForRaf();
+    expect(document.activeElement === outside).toBe(true);
+  });
+
   const waitForRaf = () =>
     new Promise<void>((resolve) => {
       requestAnimationFrame(() => resolve())

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -18,6 +18,7 @@ import {
   createPresenceLifecycle,
   getAutofocusOrFirstFocusable,
   createTerminalLifecycle,
+  drainCleanups,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -193,6 +194,7 @@ export function createPopover(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
 
   // Focus management state
   let previousActiveElement: HTMLElement | null = null;
@@ -428,8 +430,6 @@ export function createPopover(
       presence.cleanup();
       portal.cleanup();
       content.hidden = true;
-      cleanups.forEach((fn) => fn());
-      cleanups.length = 0;
       cleanupContentFocusable();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -300,6 +300,7 @@ export function createPopover(
 
   const restoreFocus = () => {
     requestAnimationFrame(() => {
+      if (isDestroyed) return;
       if (previousActiveElement && previousActiveElement.isConnected) {
         focusElement(previousActiveElement);
       } else {
@@ -328,6 +329,7 @@ export function createPopover(
   });
 
   const updateState = (open: boolean) => {
+    if (isDestroyed) return;
     if (isOpen === open) return;
 
     // Save focus target before opening
@@ -409,9 +411,9 @@ export function createPopover(
   );
 
   const controller: PopoverController = {
-    open: () => updateState(true),
-    close: () => updateState(false),
-    toggle: () => updateState(!isOpen),
+    open: () => { if (!isDestroyed) updateState(true); },
+    close: () => { if (!isDestroyed) updateState(false); },
+    toggle: () => { if (!isDestroyed) updateState(!isOpen); },
     get isOpen() {
       return isOpen;
     },

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -17,6 +17,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   getAutofocusOrFirstFocusable,
+  createTerminalLifecycle,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -192,6 +193,7 @@ export function createPopover(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
 
   // Focus management state
   let previousActiveElement: HTMLElement | null = null;
@@ -418,7 +420,7 @@ export function createPopover(
       return isOpen;
     },
     destroy: () => {
-      if (isDestroyed) return;
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       isOpen = false;
       setAria(trigger, "expanded", false);

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -194,7 +194,7 @@ export function createPopover(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
 
   // Focus management state
   let previousActiveElement: HTMLElement | null = null;

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -18,7 +18,7 @@ import {
   createPresenceLifecycle,
   getAutofocusOrFirstFocusable,
   createTerminalLifecycle,
-  drainCleanups,
+  registerFloatingTerminalResources,
 } from "@data-slot/core";
 import { setAria, ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -194,7 +194,6 @@ export function createPopover(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
 
   // Focus management state
   let previousActiveElement: HTMLElement | null = null;
@@ -426,14 +425,18 @@ export function createPopover(
       isOpen = false;
       setAria(trigger, "expanded", false);
       setDataState("closed");
-      positionSync.stop();
-      presence.cleanup();
-      portal.cleanup();
       content.hidden = true;
       cleanupContentFocusable();
-      clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };
+
+  registerFloatingTerminalResources(terminalLifecycle, {
+    cleanups,
+    positionSync,
+    presence,
+    portal,
+    unbind: () => clearRootBinding(root, ROOT_BINDING_KEY, controller),
+  });
 
   setRootBinding(root, ROOT_BINDING_KEY, controller);
   return controller;

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -301,17 +301,23 @@ export function createPopover(
     }
   };
 
-  const restoreFocus = () => {
-    terminalLifecycle.trackRaf(() => {
-      if (terminalLifecycle.isDestroyed) return;
-      if (previousActiveElement && previousActiveElement.isConnected) {
-        focusElement(previousActiveElement);
-      } else {
-        focusElement(trigger);
-      }
-      previousActiveElement = null;
-    });
+  let pendingFocusRestore = false;
+  const restoreFocusNow = () => {
+    pendingFocusRestore = false;
+    if (previousActiveElement && previousActiveElement.isConnected) {
+      focusElement(previousActiveElement);
+    } else {
+      focusElement(trigger);
+    }
+    previousActiveElement = null;
   };
+  const restoreFocus = () => {
+    pendingFocusRestore = true;
+    terminalLifecycle.trackRaf(restoreFocusNow);
+  };
+  terminalLifecycle.onBeforeDestroy(() => {
+    if (pendingFocusRestore) terminalLifecycle.trackFinalRaf(restoreFocusNow);
+  });
 
   const presence = createPresenceLifecycle({
     element: content,

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -207,6 +207,7 @@ export function createPopover(
   };
 
   const focusFirst = () => {
+    if (isDestroyed) return;
     // Priority: [autofocus] > first focusable > content itself
     const initialFocus = getAutofocusOrFirstFocusable(content);
     if (initialFocus) return initialFocus.focus();

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -192,7 +192,6 @@ export function createPopover(
     container: authoredPositioner ?? undefined,
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
 
   // Focus management state
@@ -207,7 +206,7 @@ export function createPopover(
   };
 
   const focusFirst = () => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     // Priority: [autofocus] > first focusable > content itself
     const initialFocus = getAutofocusOrFirstFocusable(content);
     if (initialFocus) return initialFocus.focus();
@@ -302,8 +301,8 @@ export function createPopover(
   };
 
   const restoreFocus = () => {
-    requestAnimationFrame(() => {
-      if (isDestroyed) return;
+    terminalLifecycle.trackRaf(() => {
+      if (terminalLifecycle.isDestroyed) return;
       if (previousActiveElement && previousActiveElement.isConnected) {
         focusElement(previousActiveElement);
       } else {
@@ -316,7 +315,7 @@ export function createPopover(
   const presence = createPresenceLifecycle({
     element: content,
     onExitComplete: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       portal.restore();
       content.hidden = true;
       cleanupContentFocusable();
@@ -332,7 +331,7 @@ export function createPopover(
   });
 
   const updateState = (open: boolean) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     if (isOpen === open) return;
 
     // Save focus target before opening
@@ -351,7 +350,7 @@ export function createPopover(
       updatePosition();
       positionSync.start();
       positionSync.update();
-      requestAnimationFrame(focusFirst);
+      terminalLifecycle.trackRaf(focusFirst);
     } else {
       setDataState("closed");
       presence.exit();
@@ -375,7 +374,7 @@ export function createPopover(
     updatePosition();
     positionSync.start();
     positionSync.update();
-    requestAnimationFrame(focusFirst);
+    terminalLifecycle.trackRaf(focusFirst);
   }
 
   // Trigger click
@@ -414,15 +413,14 @@ export function createPopover(
   );
 
   const controller: PopoverController = {
-    open: () => { if (!isDestroyed) updateState(true); },
-    close: () => { if (!isDestroyed) updateState(false); },
-    toggle: () => { if (!isDestroyed) updateState(!isOpen); },
+    open: () => { if (!terminalLifecycle.isDestroyed) updateState(true); },
+    close: () => { if (!terminalLifecycle.isDestroyed) updateState(false); },
+    toggle: () => { if (!terminalLifecycle.isDestroyed) updateState(!isOpen); },
     get isOpen() {
       return isOpen;
     },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       isOpen = false;
       setAria(trigger, "expanded", false);
       setDataState("closed");

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -416,10 +416,15 @@ export function createPopover(
       return isOpen;
     },
     destroy: () => {
+      if (isDestroyed) return;
       isDestroyed = true;
+      isOpen = false;
+      setAria(trigger, "expanded", false);
+      setDataState("closed");
       positionSync.stop();
       presence.cleanup();
       portal.cleanup();
+      content.hidden = true;
       cleanups.forEach((fn) => fn());
       cleanups.length = 0;
       cleanupContentFocusable();

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -274,3 +274,13 @@ native controls. Calling `preventDefault()` on the reset event preserves the cur
 ## License
 
 MIT
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.
+
+Focus restoration already queued by a close survives destruction.
+Closing with Tab still skips focus restoration to preserve normal Tab navigation.

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -271,12 +271,7 @@ emitting a value-change event, including when the select has no `name`.
 Synchronization happens on the next event-loop task, after the browser resets
 native controls. Calling `preventDefault()` on the reset event preserves the current state.
 
-## License
-
-MIT
-
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the
@@ -284,3 +279,7 @@ old controller become no-ops. Create a new controller on the same root to rebind
 
 Focus restoration already queued by a close survives destruction.
 Closing with Tab still skips focus restoration to preserve normal Tab navigation.
+
+## License
+
+MIT

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -3931,6 +3931,19 @@ describe("Select", () => {
       expect(changes).toEqual([true]);
     });
 
+    it("keeps a retained controller inert after destruction", () => {
+      const { root, controller } = setup();
+      controller.destroy();
+
+      controller.open();
+      controller.select("apple");
+      controller.close();
+
+      expect(controller.isOpen).toBe(false);
+      expect(root.getAttribute("data-state")).toBe("closed");
+      expect(document.documentElement.style.overflow).toBe("");
+    });
+
     it("uses authored portal and positioner slots when provided", async () => {
       document.body.innerHTML = `
         <div data-slot="select" id="root">

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -34,6 +34,45 @@ describe("Select", () => {
     return { root, trigger, content, valueSlot, items, controller };
   };
 
+  it("preserves queued close focus restoration when destroyed before the next frame", async () => {
+    const { trigger, content, controller } = setup();
+    trigger.focus();
+    controller.open();
+    await waitForRaf();
+    await waitForRaf();
+    content.focus();
+    controller.close();
+    await waitForRaf();
+    controller.destroy();
+    controller.destroy();
+    await waitForRaf();
+    await waitForRaf();
+    expect(document.activeElement === trigger).toBe(true);
+  });
+
+  it("does not move outside focus when destroyed without a pending restoration", async () => {
+    const { controller } = setup();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.focus();
+    controller.destroy();
+    await waitForRaf();
+    expect(document.activeElement === outside).toBe(true);
+  });
+
+  it("preserves Tab focus when destroyed after a close that skips restoration", async () => {
+    const { content, controller } = setup();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    controller.open();
+    content.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    outside.focus();
+    await waitForRaf();
+    controller.destroy();
+    await waitForRaf();
+    expect(document.activeElement === outside).toBe(true);
+  });
+
   const waitForRaf = () =>
     new Promise<void>((resolve) => {
       requestAnimationFrame(() => resolve());

--- a/packages/select/src/index.test.ts
+++ b/packages/select/src/index.test.ts
@@ -3912,6 +3912,25 @@ describe("Select", () => {
       expect(content.parentElement).toBe(root);
     });
 
+    it("terminally closes without emitting when destroyed while open", () => {
+      const { root, trigger, content, controller } = setup();
+      const changes: boolean[] = [];
+      root.addEventListener("select:open-change", (event) => {
+        changes.push((event as CustomEvent<{ open: boolean }>).detail.open);
+      });
+
+      controller.open();
+      controller.destroy();
+      controller.destroy();
+
+      expect(controller.isOpen).toBe(false);
+      expect(root.getAttribute("data-state")).toBe("closed");
+      expect(content.getAttribute("data-state")).toBe("closed");
+      expect(content.hidden).toBe(true);
+      expect(trigger.getAttribute("aria-expanded")).toBe("false");
+      expect(changes).toEqual([true]);
+    });
+
     it("uses authored portal and positioner slots when provided", async () => {
       document.body.innerHTML = `
         <div data-slot="select" id="root">

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -294,17 +294,23 @@ export function createSelect(
     }
   };
 
-  const restoreFocus = () => {
-    terminalLifecycle.trackRaf(() => {
-      if (terminalLifecycle.isDestroyed) return;
-      if (previousActiveElement && document.contains(previousActiveElement)) {
-        focusElement(previousActiveElement);
-      } else if (trigger && document.contains(trigger)) {
-        focusElement(trigger);
-      }
-      previousActiveElement = null;
-    });
+  let pendingFocusRestore = false;
+  const restoreFocusNow = () => {
+    pendingFocusRestore = false;
+    if (previousActiveElement && document.contains(previousActiveElement)) {
+      focusElement(previousActiveElement);
+    } else if (trigger && document.contains(trigger)) {
+      focusElement(trigger);
+    }
+    previousActiveElement = null;
   };
+  const restoreFocus = () => {
+    pendingFocusRestore = true;
+    terminalLifecycle.trackRaf(restoreFocusNow);
+  };
+  terminalLifecycle.onBeforeDestroy(() => {
+    if (pendingFocusRestore) terminalLifecycle.trackFinalRaf(restoreFocusNow);
+  });
 
   const finishClose = () => {
     if (terminalLifecycle.isDestroyed) return;

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -114,7 +114,7 @@ export function createSelect(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   terminalLifecycle.onDestroy(() => {
     if (didLockScroll) {
       unlockScroll();

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -664,11 +664,6 @@ export function createSelect(
       setAria(trigger, "expanded", false);
       setDataState("closed");
       content.hidden = true;
-      // Unlock scroll if still locked
-      if (didLockScroll) {
-        unlockScroll();
-        didLockScroll = false;
-      }
       formField?.destroy();
     },
   };

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -17,6 +17,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
+  drainCleanups,
   createDismissLayer,
 } from "@data-slot/core";
 import type { SelectController, SelectOptions } from "./types";
@@ -113,6 +114,7 @@ export function createSelect(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
   terminalLifecycle.onDestroy(() => {
     if (didLockScroll) {
       unlockScroll();
@@ -671,8 +673,6 @@ export function createSelect(
         unlockScroll();
         didLockScroll = false;
       }
-      cleanups.forEach((fn) => fn());
-      cleanups.length = 0;
       formField?.destroy();
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -16,6 +16,7 @@ import {
   focusElement,
   createPortalLifecycle,
   createPresenceLifecycle,
+  createTerminalLifecycle,
   createDismissLayer,
 } from "@data-slot/core";
 import type { SelectController, SelectOptions } from "./types";
@@ -112,6 +113,7 @@ export function createSelect(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
   let shouldRestoreFocusOnClose = true;
 
   const isItemDisabled = (el: HTMLElement) =>
@@ -650,7 +652,7 @@ export function createSelect(
     open: () => { if (!isDestroyed) updateOpenState(true); },
     close: () => { if (!isDestroyed) updateOpenState(false); },
     destroy: () => {
-      if (isDestroyed) return;
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       typeahead.destroy();
       isOpen = false;

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -288,6 +288,7 @@ export function createSelect(
 
   const restoreFocus = () => {
     requestAnimationFrame(() => {
+      if (isDestroyed) return;
       if (previousActiveElement && document.contains(previousActiveElement)) {
         focusElement(previousActiveElement);
       } else if (trigger && document.contains(trigger)) {
@@ -331,6 +332,7 @@ export function createSelect(
     open: boolean,
     options: { skipFocusRestore?: boolean; immediate?: boolean } = {}
   ) => {
+    if (isDestroyed) return;
     const { skipFocusRestore = false, immediate = false } = options;
 
     if (isOpen === open) return;
@@ -365,7 +367,7 @@ export function createSelect(
       // Use rAF to refine position after browser has fully rendered content,
       // and to highlight item under cursor if pointer opened the select
       requestAnimationFrame(() => {
-        if (!isOpen) return;
+        if (isDestroyed || !isOpen) return;
         positioning.update();
         positioning.sync();
 
@@ -421,6 +423,7 @@ export function createSelect(
   };
 
   const updateValue = (value: string | null, init = false) => {
+    if (isDestroyed) return;
     if (currentValue === value && !init) return;
 
     const oldValue = currentValue;
@@ -643,9 +646,9 @@ export function createSelect(
   const controller: SelectController = {
     get value() { return currentValue; },
     get isOpen() { return isOpen; },
-    select: (value: string) => updateValue(value),
-    open: () => updateOpenState(true),
-    close: () => updateOpenState(false),
+    select: (value: string) => { if (!isDestroyed) updateValue(value); },
+    open: () => { if (!isDestroyed) updateOpenState(true); },
+    close: () => { if (!isDestroyed) updateOpenState(false); },
     destroy: () => {
       if (isDestroyed) return;
       isDestroyed = true;

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -647,11 +647,16 @@ export function createSelect(
     open: () => updateOpenState(true),
     close: () => updateOpenState(false),
     destroy: () => {
+      if (isDestroyed) return;
       isDestroyed = true;
       typeahead.destroy();
+      isOpen = false;
+      setAria(trigger, "expanded", false);
+      setDataState("closed");
       positioning.stop();
       presence.cleanup();
       portal.cleanup();
+      content.hidden = true;
       // Unlock scroll if still locked
       if (didLockScroll) {
         unlockScroll();

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -17,7 +17,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
-  drainCleanups,
+  registerFloatingTerminalResources,
   createDismissLayer,
 } from "@data-slot/core";
 import type { SelectController, SelectOptions } from "./types";
@@ -114,7 +114,6 @@ export function createSelect(
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   terminalLifecycle.onDestroy(() => {
     if (didLockScroll) {
       unlockScroll();
@@ -664,9 +663,6 @@ export function createSelect(
       isOpen = false;
       setAria(trigger, "expanded", false);
       setDataState("closed");
-      positioning.stop();
-      presence.cleanup();
-      portal.cleanup();
       content.hidden = true;
       // Unlock scroll if still locked
       if (didLockScroll) {
@@ -674,9 +670,16 @@ export function createSelect(
         didLockScroll = false;
       }
       formField?.destroy();
-      clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };
+
+  registerFloatingTerminalResources(terminalLifecycle, {
+    cleanups,
+    positionSync: positioning,
+    presence,
+    portal,
+    unbind: () => clearRootBinding(root, ROOT_BINDING_KEY, controller),
+  });
 
   setRootBinding(root, ROOT_BINDING_KEY, controller);
 

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -112,8 +112,13 @@ export function createSelect(
     container: authoredPositioner ?? undefined,
     mountTarget: authoredPositioner ? authoredPortal ?? authoredPositioner : undefined,
   });
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroy(() => {
+    if (didLockScroll) {
+      unlockScroll();
+      didLockScroll = false;
+    }
+  });
   let shouldRestoreFocusOnClose = true;
 
   const isItemDisabled = (el: HTMLElement) =>
@@ -289,8 +294,8 @@ export function createSelect(
   };
 
   const restoreFocus = () => {
-    requestAnimationFrame(() => {
-      if (isDestroyed) return;
+    terminalLifecycle.trackRaf(() => {
+      if (terminalLifecycle.isDestroyed) return;
       if (previousActiveElement && document.contains(previousActiveElement)) {
         focusElement(previousActiveElement);
       } else if (trigger && document.contains(trigger)) {
@@ -301,7 +306,7 @@ export function createSelect(
   };
 
   const finishClose = () => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     portal.restore();
     content.hidden = true;
     if (shouldRestoreFocusOnClose) {
@@ -334,7 +339,7 @@ export function createSelect(
     open: boolean,
     options: { skipFocusRestore?: boolean; immediate?: boolean } = {}
   ) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     const { skipFocusRestore = false, immediate = false } = options;
 
     if (isOpen === open) return;
@@ -368,8 +373,8 @@ export function createSelect(
 
       // Use rAF to refine position after browser has fully rendered content,
       // and to highlight item under cursor if pointer opened the select
-      requestAnimationFrame(() => {
-        if (isDestroyed || !isOpen) return;
+      terminalLifecycle.trackRaf(() => {
+        if (terminalLifecycle.isDestroyed || !isOpen) return;
         positioning.update();
         positioning.sync();
 
@@ -425,7 +430,7 @@ export function createSelect(
   };
 
   const updateValue = (value: string | null, init = false) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     if (currentValue === value && !init) return;
 
     const oldValue = currentValue;
@@ -648,12 +653,11 @@ export function createSelect(
   const controller: SelectController = {
     get value() { return currentValue; },
     get isOpen() { return isOpen; },
-    select: (value: string) => { if (!isDestroyed) updateValue(value); },
-    open: () => { if (!isDestroyed) updateOpenState(true); },
-    close: () => { if (!isDestroyed) updateOpenState(false); },
+    select: (value: string) => { if (!terminalLifecycle.isDestroyed) updateValue(value); },
+    open: () => { if (!terminalLifecycle.isDestroyed) updateOpenState(true); },
+    close: () => { if (!terminalLifecycle.isDestroyed) updateOpenState(false); },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       typeahead.destroy();
       isOpen = false;
       setAria(trigger, "expanded", false);

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -423,3 +423,13 @@ Use `{ open: boolean }` instead.
 ## License
 
 MIT
+
+
+### Controller destruction
+
+`destroy()` permanently disposes the controller and hides any open surface without
+emitting an additional change event. Repeated destruction is safe; methods on the
+old controller become no-ops. Create a new controller on the same root to rebind it.
+
+Cleanup removes only the description reference added by this tooltip; authored
+`aria-describedby` references are preserved.

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -420,12 +420,7 @@ element.dispatchEvent(
 
 Use `{ open: boolean }` instead.
 
-## License
-
-MIT
-
-
-### Controller destruction
+## Controller destruction
 
 `destroy()` permanently disposes the controller and hides any open surface without
 emitting an additional change event. Repeated destruction is safe; methods on the
@@ -433,3 +428,7 @@ old controller become no-ops. Create a new controller on the same root to rebind
 
 Cleanup removes only the description reference added by this tooltip; authored
 `aria-describedby` references are preserved.
+
+## License
+
+MIT

--- a/packages/tooltip/src/index.test.ts
+++ b/packages/tooltip/src/index.test.ts
@@ -126,6 +126,34 @@ describe('Tooltip', () => {
     controller.destroy()
   })
 
+  it('preserves authored descriptions when destroyed before opening', () => {
+    const { trigger, controller } = setup()
+    trigger.setAttribute('aria-describedby', 'author-help other-help')
+    controller.destroy()
+    expect(trigger.getAttribute('aria-describedby')).toBe('author-help other-help')
+  })
+
+  it('only removes its own description after opening, closing, and destruction', () => {
+    const { trigger, content, controller } = setup()
+    trigger.setAttribute('aria-describedby', 'author-help')
+    controller.show()
+    expect(trigger.getAttribute('aria-describedby')).toBe(`author-help ${content.id}`)
+    controller.hide()
+    expect(trigger.getAttribute('aria-describedby')).toBe('author-help')
+    controller.show()
+    trigger.setAttribute('aria-describedby', `${trigger.getAttribute('aria-describedby')} added-later`)
+    controller.destroy()
+    expect(trigger.getAttribute('aria-describedby')).toBe('author-help added-later')
+  })
+
+  it('preserves an author-owned reference to the tooltip content itself', () => {
+    const { trigger, content, controller } = setup()
+    trigger.setAttribute('aria-describedby', content.id)
+    controller.show()
+    controller.destroy()
+    expect(trigger.getAttribute('aria-describedby')).toBe(content.id)
+  })
+
   it('removes accessibility wiring when destroyed while open', () => {
     const { trigger, content, controller } = setup()
     controller.show()

--- a/packages/tooltip/src/index.test.ts
+++ b/packages/tooltip/src/index.test.ts
@@ -126,6 +126,18 @@ describe('Tooltip', () => {
     controller.destroy()
   })
 
+  it('removes accessibility wiring when destroyed while open', () => {
+    const { trigger, content, controller } = setup()
+    controller.show()
+    expect(trigger.hasAttribute('aria-describedby')).toBe(true)
+
+    controller.destroy()
+
+    expect(trigger.hasAttribute('aria-describedby')).toBe(false)
+    expect(content.getAttribute('aria-hidden')).toBe('true')
+    expect(content.hidden).toBe(true)
+  })
+
   it('shows immediately via controller.show()', () => {
     const { root, controller } = setup()
 

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -17,6 +17,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
+  drainCleanups,
 } from "@data-slot/core";
 import { ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -219,6 +220,7 @@ export function createTooltip(
   let instantType: TooltipInstantType = null;
   let hasFocus = false;
   const terminalLifecycle = createTerminalLifecycle();
+  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
   let showTimeout: ReturnType<typeof setTimeout> | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -631,8 +633,6 @@ export function createTooltip(
       presence.cleanup();
       portal.cleanup();
       content.hidden = true;
-      cleanups.forEach((fn) => fn());
-      cleanups.length = 0;
       clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -409,6 +409,7 @@ export function createTooltip(
     reason: TooltipReason,
     nextInstantType: TooltipInstantType = null
   ) => {
+    if (isDestroyed) return;
     if (isOpen === open) return;
 
     if (!open && isOpen && skipDelayDuration > 0) {
@@ -454,6 +455,7 @@ export function createTooltip(
     }
 
     showTimeout = setTimeout(() => {
+      if (isDestroyed) return;
       updateState(true, reason, reason === "focus" ? "focus" : null);
       showTimeout = null;
     }, delay);
@@ -603,6 +605,7 @@ export function createTooltip(
 
   const controller: TooltipController = {
     show: () => {
+      if (isDestroyed) return;
       // Respect disabled state even for programmatic calls
       if (isTriggerDisabled()) return;
       if (showTimeout) {
@@ -611,7 +614,7 @@ export function createTooltip(
       }
       updateState(true, "api");
     },
-    hide: () => hideImmediately("api"),
+    hide: () => { if (!isDestroyed) hideImmediately("api"); },
     get isOpen() {
       return isOpen;
     },
@@ -622,6 +625,8 @@ export function createTooltip(
       showTimeout = null;
       isOpen = false;
       setDataState("closed");
+      trigger.removeAttribute("aria-describedby");
+      content.setAttribute("aria-hidden", "true");
       positionSync.stop();
       presence.cleanup();
       portal.cleanup();

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -234,6 +234,22 @@ export function createTooltip(
 
   // ARIA setup - ensure content has stable id
   const contentId = ensureId(content, "tooltip-content");
+  let ownsDescription = false;
+  const descriptionIds = () =>
+    trigger.getAttribute("aria-describedby")?.split(/\s+/).filter(Boolean) ?? [];
+  const addDescription = () => {
+    const ids = descriptionIds();
+    if (ids.includes(contentId)) return;
+    trigger.setAttribute("aria-describedby", [...ids, contentId].join(" "));
+    ownsDescription = true;
+  };
+  const removeDescription = () => {
+    if (!ownsDescription) return;
+    const ids = descriptionIds().filter((id) => id !== contentId);
+    if (ids.length) trigger.setAttribute("aria-describedby", ids.join(" "));
+    else trigger.removeAttribute("aria-describedby");
+    ownsDescription = false;
+  };
   content.setAttribute("role", "tooltip");
   const resolveDirection = (): TooltipDirection => {
     const rootElement = root instanceof HTMLElement ? root : null;
@@ -422,7 +438,7 @@ export function createTooltip(
     isOpen = open;
 
     if (isOpen) {
-      trigger.setAttribute("aria-describedby", contentId);
+      addDescription();
       content.setAttribute("aria-hidden", "false");
       portal.mount();
       content.hidden = false;
@@ -433,7 +449,7 @@ export function createTooltip(
       positionSync.update();
     } else {
       setDataState("closed");
-      trigger.removeAttribute("aria-describedby");
+      removeDescription();
       content.setAttribute("aria-hidden", "true");
       presence.exit();
       positionSync.stop();
@@ -626,7 +642,7 @@ export function createTooltip(
       showTimeout = null;
       isOpen = false;
       setDataState("closed");
-      trigger.removeAttribute("aria-describedby");
+      removeDescription();
       content.setAttribute("aria-hidden", "true");
       content.hidden = true;
     },

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -16,6 +16,7 @@ import {
   createPositionSync,
   createPortalLifecycle,
   createPresenceLifecycle,
+  createTerminalLifecycle,
 } from "@data-slot/core";
 import { ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -218,6 +219,7 @@ export function createTooltip(
   let instantType: TooltipInstantType = null;
   let hasFocus = false;
   let isDestroyed = false;
+  const terminalLifecycle = createTerminalLifecycle();
   let showTimeout: ReturnType<typeof setTimeout> | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -619,7 +621,7 @@ export function createTooltip(
       return isOpen;
     },
     destroy: () => {
-      if (isDestroyed) return;
+      if (!terminalLifecycle.destroy()) return;
       isDestroyed = true;
       if (showTimeout) clearTimeout(showTimeout);
       showTimeout = null;

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -616,11 +616,16 @@ export function createTooltip(
       return isOpen;
     },
     destroy: () => {
+      if (isDestroyed) return;
       isDestroyed = true;
       if (showTimeout) clearTimeout(showTimeout);
+      showTimeout = null;
+      isOpen = false;
+      setDataState("closed");
       positionSync.stop();
       presence.cleanup();
       portal.cleanup();
+      content.hidden = true;
       cleanups.forEach((fn) => fn());
       cleanups.length = 0;
       clearRootBinding(root, ROOT_BINDING_KEY, controller);

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -446,7 +446,7 @@ export function createTooltip(
   const showWithDelay = (reason: TooltipReason) => {
     // Always reset timer on re-enter for predictable behavior
     if (showTimeout) {
-      clearTimeout(showTimeout);
+      terminalLifecycle.cancelTimeout(showTimeout);
       showTimeout = null;
     }
 
@@ -468,7 +468,7 @@ export function createTooltip(
     nextInstantType: TooltipInstantType = null
   ) => {
     if (showTimeout) {
-      clearTimeout(showTimeout);
+      terminalLifecycle.cancelTimeout(showTimeout);
       showTimeout = null;
     }
 
@@ -521,7 +521,7 @@ export function createTooltip(
 
       // If a delayed open is pending and user clicks first, cancel opening.
       if (showTimeout) {
-        clearTimeout(showTimeout);
+        terminalLifecycle.cancelTimeout(showTimeout);
         showTimeout = null;
         return;
       }
@@ -584,7 +584,7 @@ export function createTooltip(
       if (open) {
         if (isTriggerDisabled()) return; // Opening respects disabled
         if (showTimeout) {
-          clearTimeout(showTimeout);
+          terminalLifecycle.cancelTimeout(showTimeout);
           showTimeout = null;
         }
         updateState(true, "api");
@@ -611,7 +611,7 @@ export function createTooltip(
       // Respect disabled state even for programmatic calls
       if (isTriggerDisabled()) return;
       if (showTimeout) {
-        clearTimeout(showTimeout);
+        terminalLifecycle.cancelTimeout(showTimeout);
         showTimeout = null;
       }
       updateState(true, "api");
@@ -622,7 +622,7 @@ export function createTooltip(
     },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      if (showTimeout) clearTimeout(showTimeout);
+      if (showTimeout) terminalLifecycle.cancelTimeout(showTimeout);
       showTimeout = null;
       isOpen = false;
       setDataState("closed");

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -220,7 +220,7 @@ export function createTooltip(
   let instantType: TooltipInstantType = null;
   let hasFocus = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroyBundle([() => drainCleanups(cleanups)]);
+  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   let showTimeout: ReturnType<typeof setTimeout> | null = null;
   const cleanups: Array<() => void> = [];
 

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -218,7 +218,6 @@ export function createTooltip(
   let isOpen = false;
   let instantType: TooltipInstantType = null;
   let hasFocus = false;
-  let isDestroyed = false;
   const terminalLifecycle = createTerminalLifecycle();
   let showTimeout: ReturnType<typeof setTimeout> | null = null;
   const cleanups: Array<() => void> = [];
@@ -389,7 +388,7 @@ export function createTooltip(
   const presence = createPresenceLifecycle({
     element: content,
     onExitComplete: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       portal.restore();
       content.hidden = true;
     },
@@ -411,7 +410,7 @@ export function createTooltip(
     reason: TooltipReason,
     nextInstantType: TooltipInstantType = null
   ) => {
-    if (isDestroyed) return;
+    if (terminalLifecycle.isDestroyed) return;
     if (isOpen === open) return;
 
     if (!open && isOpen && skipDelayDuration > 0) {
@@ -456,8 +455,8 @@ export function createTooltip(
       return;
     }
 
-    showTimeout = setTimeout(() => {
-      if (isDestroyed) return;
+    showTimeout = terminalLifecycle.trackTimeout(() => {
+      if (terminalLifecycle.isDestroyed) return;
       updateState(true, reason, reason === "focus" ? "focus" : null);
       showTimeout = null;
     }, delay);
@@ -607,7 +606,7 @@ export function createTooltip(
 
   const controller: TooltipController = {
     show: () => {
-      if (isDestroyed) return;
+      if (terminalLifecycle.isDestroyed) return;
       // Respect disabled state even for programmatic calls
       if (isTriggerDisabled()) return;
       if (showTimeout) {
@@ -616,13 +615,12 @@ export function createTooltip(
       }
       updateState(true, "api");
     },
-    hide: () => { if (!isDestroyed) hideImmediately("api"); },
+    hide: () => { if (!terminalLifecycle.isDestroyed) hideImmediately("api"); },
     get isOpen() {
       return isOpen;
     },
     destroy: () => {
       if (!terminalLifecycle.destroy()) return;
-      isDestroyed = true;
       if (showTimeout) clearTimeout(showTimeout);
       showTimeout = null;
       isOpen = false;

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -17,7 +17,7 @@ import {
   createPortalLifecycle,
   createPresenceLifecycle,
   createTerminalLifecycle,
-  drainCleanups,
+  registerFloatingTerminalResources,
 } from "@data-slot/core";
 import { ensureId } from "@data-slot/core";
 import { on, onRoot, emit } from "@data-slot/core";
@@ -220,7 +220,6 @@ export function createTooltip(
   let instantType: TooltipInstantType = null;
   let hasFocus = false;
   const terminalLifecycle = createTerminalLifecycle();
-  terminalLifecycle.onDestroy(() => drainCleanups(cleanups));
   let showTimeout: ReturnType<typeof setTimeout> | null = null;
   const cleanups: Array<() => void> = [];
 
@@ -629,13 +628,17 @@ export function createTooltip(
       setDataState("closed");
       trigger.removeAttribute("aria-describedby");
       content.setAttribute("aria-hidden", "true");
-      positionSync.stop();
-      presence.cleanup();
-      portal.cleanup();
       content.hidden = true;
-      clearRootBinding(root, ROOT_BINDING_KEY, controller);
     },
   };
+
+  registerFloatingTerminalResources(terminalLifecycle, {
+    cleanups,
+    positionSync,
+    presence,
+    portal,
+    unbind: () => clearRootBinding(root, ROOT_BINDING_KEY, controller),
+  });
 
   setRootBinding(root, ROOT_BINDING_KEY, controller);
   return controller;


### PR DESCRIPTION
Destroying an open floating controller could leave its popup visible and its open state stale, and retained controller references could continue mutating the component after cleanup. This change makes destruction terminal across select, combobox, dropdown-menu, popover, tooltip, hover-card, navigation-menu, dialog, and alert-dialog.

A shared lifecycle cancels pending timers and animation frames and disposes positioning, presence, portal, listener, modal, and root-binding resources. Floating controllers reset their visibility and accessibility state without emitting an extra close event. Modal teardown restores focus to the previous target, falls back to a surviving trigger when that target was removed, and leaves outside focus alone when the modal was never opened. Explicit cancellation also removes handles from lifecycle tracking immediately.

### Compatibility

Existing component options, markup, event names, and declared controller signatures are unchanged; core lifecycle exports are additive. After `destroy()`, retained controller methods become no-ops. Consumers must create a fresh controller to rebind a root. Open-state getters and DOM attributes now reflect the destroyed state.

Dialog and alert-dialog preserve their existing `undefined` return value. Component READMEs document the terminal destruction contract, and the core README documents the new lifecycle APIs. Pending close-focus restoration in popover, select, and dropdown-menu survives destruction; Select still skips restoration when closing with Tab. Tooltip cleanup preserves author-owned `aria-describedby` references, including descriptions present before opening and descriptions added while open.

### Validation

- `bun test`: 1,402 passing tests across 24 files.
- `bun run typecheck`: 143 errors, matching the `origin/main` baseline with no additional diagnostics after normalizing shifted line numbers.
- `git diff --check`: passes.
- Browser comparison using separately bundled main and branch sources: stale-controller reuse, same-root rebinding, dialog and alert-dialog focus fallback, delayed hover, 100 canceled tooltip timers, close-then-destroy focus restoration for all three floating controls, and authored tooltip descriptions. The throwaway comparison is kept outside the repository.

### Manual verification

1. Open a select, destroy it, then call `open()` on the retained controller. It should stay hidden with `isOpen === false` and `aria-expanded="false"`.
2. Rebind the same root, open the new controller, then destroy the old reference again. The new controller should remain usable.
3. Open a modal from an outside focus target, remove that target, and destroy the modal. Focus should return to the surviving trigger. Destroying an unopened modal should preserve outside focus.
4. Queue a delayed hover and destroy before the timer fires. No popup should appear; calls on the old controller should remain inert.

5. Close a popover, select, or dropdown-menu, wait one animation frame, then destroy it. The pending restoration should still return focus to its surviving target. Select closed with Tab must keep focus outside.
6. Give a tooltip trigger an authored `aria-describedby`, then destroy it without opening, or open and destroy it. The author-owned reference should remain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/data-slot/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791714263&installation_model_id=433409&pr_number=20&repository=bejamas%2Fdata-slot&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fdata-slot%2Fpull%2F20&signature=4f8b041243f222131b0476f08ec52fac724f2b5ffefad3ccad731cc0e3f7291f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
